### PR TITLE
Add randomizers for MAC, IPv4 and IPv6 addresses

### DIFF
--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/FakerBasedRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/FakerBasedRandomizer.java
@@ -38,19 +38,16 @@ public abstract class FakerBasedRandomizer<T> extends AbstractRandomizer<T> {
 
     final Faker faker;
 
-    FakerBasedRandomizer() {
+    protected FakerBasedRandomizer() {
         faker = new Faker(Locale.ENGLISH);
     }
 
-    FakerBasedRandomizer(final long seed) {
+    protected FakerBasedRandomizer(final long seed) {
         this(seed, Locale.ENGLISH);
     }
 
-    FakerBasedRandomizer(final long seed, final Locale locale) {
+    protected FakerBasedRandomizer(final long seed, final Locale locale) {
         super(seed);
         faker = new Faker(locale, random);
     }
-
-    @Override
-    public abstract T getRandomValue();
 }

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/FakerBasedRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/FakerBasedRandomizer.java
@@ -36,7 +36,7 @@ import java.util.Locale;
  */
 public abstract class FakerBasedRandomizer<T> extends AbstractRandomizer<T> {
 
-    final Faker faker;
+    protected final Faker faker;
 
     protected FakerBasedRandomizer() {
         faker = new Faker(Locale.ENGLISH);

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/Ipv4AddressRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/Ipv4AddressRandomizer.java
@@ -1,0 +1,103 @@
+/**
+ * The MIT License
+ * <p>
+ * Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jeasy.random.randomizers;
+
+import org.jeasy.random.api.Randomizer;
+
+import java.util.Locale;
+
+/**
+ * A {@link Randomizer} that generates random IPv4 addresses.
+ *
+ * @author Michael Düsterhus
+ */
+public class Ipv4AddressRandomizer extends FakerBasedRandomizer<String> {
+
+    /**
+     * Create a new {@link Ipv4AddressRandomizer}.
+     */
+    public Ipv4AddressRandomizer() {
+    }
+
+    /**
+     * Create a new {@link Ipv4AddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     */
+    public Ipv4AddressRandomizer(long seed) {
+        super(seed);
+    }
+
+    /**
+     * Create a new {@link Ipv4AddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @param locale
+     *          the locale to use
+     */
+    public Ipv4AddressRandomizer(final long seed, final Locale locale) {
+        super(seed, locale);
+    }
+
+    /**
+     * Create a new {@link Ipv4AddressRandomizer}.
+     *
+     * @return a new {@link Ipv4AddressRandomizer}
+     */
+    public static Ipv4AddressRandomizer aNewIpv4AddressRandomizer() {
+        return new Ipv4AddressRandomizer();
+    }
+
+    /**
+     * Create a new {@link Ipv4AddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @return a new {@link Ipv4AddressRandomizer}
+     */
+    public static Ipv4AddressRandomizer aNewIpv4AddressRandomizer(final long seed) {
+        return new Ipv4AddressRandomizer(seed);
+    }
+
+    /**
+     * Create a new {@link Ipv4AddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @param locale
+     *          the locale to use
+     * @return a new {@link Ipv4AddressRandomizer}
+     */
+    public static Ipv4AddressRandomizer aNewIpv4AddressRandomizer(final long seed, final Locale locale) {
+        return new Ipv4AddressRandomizer(seed, locale);
+    }
+
+    @Override
+    public String getRandomValue() {
+        return faker.internet().ipV4Address();
+    }
+
+}

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/Ipv6AddressRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/Ipv6AddressRandomizer.java
@@ -1,0 +1,103 @@
+/**
+ * The MIT License
+ * <p>
+ * Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jeasy.random.randomizers;
+
+import org.jeasy.random.api.Randomizer;
+
+import java.util.Locale;
+
+/**
+ * A {@link Randomizer} that generates random IPv6 addresses.
+ *
+ * @author Michael Düsterhus
+ */
+public class Ipv6AddressRandomizer extends FakerBasedRandomizer<String> {
+
+    /**
+     * Create a new {@link Ipv6AddressRandomizer}.
+     */
+    public Ipv6AddressRandomizer() {
+    }
+
+    /**
+     * Create a new {@link Ipv6AddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     */
+    public Ipv6AddressRandomizer(long seed) {
+        super(seed);
+    }
+
+    /**
+     * Create a new {@link Ipv6AddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @param locale
+     *          the locale to use
+     */
+    public Ipv6AddressRandomizer(final long seed, final Locale locale) {
+        super(seed, locale);
+    }
+
+    /**
+     * Create a new {@link Ipv6AddressRandomizer}.
+     *
+     * @return a new {@link Ipv6AddressRandomizer}
+     */
+    public static Ipv6AddressRandomizer aNewIpv6AddressRandomizer() {
+        return new Ipv6AddressRandomizer();
+    }
+
+    /**
+     * Create a new {@link Ipv6AddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @return a new {@link Ipv6AddressRandomizer}
+     */
+    public static Ipv6AddressRandomizer aNewIpv6AddressRandomizer(final long seed) {
+        return new Ipv6AddressRandomizer(seed);
+    }
+
+    /**
+     * Create a new {@link Ipv6AddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @param locale
+     *          the locale to use
+     * @return a new {@link Ipv6AddressRandomizer}
+     */
+    public static Ipv6AddressRandomizer aNewIpv6AddressRandomizer(final long seed, final Locale locale) {
+        return new Ipv6AddressRandomizer(seed, locale);
+    }
+
+    @Override
+    public String getRandomValue() {
+        return faker.internet().ipV6Address();
+    }
+
+}

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/MacAddressRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/MacAddressRandomizer.java
@@ -1,0 +1,103 @@
+/**
+ * The MIT License
+ * <p>
+ * Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jeasy.random.randomizers;
+
+import org.jeasy.random.api.Randomizer;
+
+import java.util.Locale;
+
+/**
+ * A {@link Randomizer} that generates random mac addresses.
+ *
+ * @author Michael Düsterhus
+ */
+public class MacAddressRandomizer extends FakerBasedRandomizer<String> {
+
+    /**
+     * Create a new {@link MacAddressRandomizer}.
+     */
+    public MacAddressRandomizer() {
+    }
+
+    /**
+     * Create a new {@link MacAddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     */
+    public MacAddressRandomizer(long seed) {
+        super(seed);
+    }
+
+    /**
+     * Create a new {@link MacAddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @param locale
+     *          the locale to use
+     */
+    public MacAddressRandomizer(final long seed, final Locale locale) {
+        super(seed, locale);
+    }
+
+    /**
+     * Create a new {@link MacAddressRandomizer}.
+     *
+     * @return a new {@link MacAddressRandomizer}
+     */
+    public static MacAddressRandomizer aNewMacAddressRandomizer() {
+        return new MacAddressRandomizer();
+    }
+
+    /**
+     * Create a new {@link MacAddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @return a new {@link MacAddressRandomizer}
+     */
+    public static MacAddressRandomizer aNewMacAddressRandomizer(final long seed) {
+        return new MacAddressRandomizer(seed);
+    }
+
+    /**
+     * Create a new {@link MacAddressRandomizer}.
+     *
+     * @param seed
+     *          the initial seed
+     * @param locale
+     *          the locale to use
+     * @return a new {@link MacAddressRandomizer}
+     */
+    public static MacAddressRandomizer aNewMacAddressRandomizer(final long seed, final Locale locale) {
+        return new MacAddressRandomizer(seed, locale);
+    }
+
+    @Override
+    public String getRandomValue() {
+        return faker.internet().macAddress();
+    }
+
+}

--- a/easy-random-randomizers/src/test/java/org/jeasy/random/randomizers/RandomizersTest.java
+++ b/easy-random-randomizers/src/test/java/org/jeasy/random/randomizers/RandomizersTest.java
@@ -30,10 +30,13 @@ import static org.jeasy.random.randomizers.CreditCardNumberRandomizer.aNewCredit
 import static org.jeasy.random.randomizers.EmailRandomizer.aNewEmailRandomizer;
 import static org.jeasy.random.randomizers.FirstNameRandomizer.aNewFirstNameRandomizer;
 import static org.jeasy.random.randomizers.FullNameRandomizer.aNewFullNameRandomizer;
+import static org.jeasy.random.randomizers.Ipv4AddressRandomizer.aNewIpv4AddressRandomizer;
+import static org.jeasy.random.randomizers.Ipv6AddressRandomizer.aNewIpv6AddressRandomizer;
 import static org.jeasy.random.randomizers.IsbnRandomizer.aNewIsbnRandomizer;
 import static org.jeasy.random.randomizers.LastNameRandomizer.aNewLastNameRandomizer;
 import static org.jeasy.random.randomizers.LatitudeRandomizer.aNewLatitudeRandomizer;
 import static org.jeasy.random.randomizers.LongitudeRandomizer.aNewLongitudeRandomizer;
+import static org.jeasy.random.randomizers.MacAddressRandomizer.aNewMacAddressRandomizer;
 import static org.jeasy.random.randomizers.ParagraphRandomizer.aNewParagraphRandomizer;
 import static org.jeasy.random.randomizers.PhoneNumberRandomizer.aNewPhoneNumberRandomizer;
 import static org.jeasy.random.randomizers.RegularExpressionRandomizer.aNewRegularExpressionRandomizer;
@@ -62,10 +65,13 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
                 aNewEmailRandomizer(),
                 aNewFirstNameRandomizer(),
                 aNewFullNameRandomizer(),
+                aNewIpv4AddressRandomizer(),
+                aNewIpv6AddressRandomizer(),
                 aNewIsbnRandomizer(),
                 aNewLastNameRandomizer(),
                 aNewLatitudeRandomizer(),
                 aNewLongitudeRandomizer(),
+                aNewMacAddressRandomizer(),
                 aNewPhoneNumberRandomizer(),
                 aNewRegularExpressionRandomizer("\\d+[A-Z]{5}"),
                 aNewParagraphRandomizer(),
@@ -95,10 +101,13 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
                 { aNewEmailRandomizer(SEED), "jacob.hansen@hotmail.com" }, 
                 { aNewFirstNameRandomizer(SEED), "Jacob" },
                 { aNewFullNameRandomizer(SEED), "Breanna Mills" },
+                { aNewIpv4AddressRandomizer(SEED), "16.188.76.229" },
+                { aNewIpv6AddressRandomizer(SEED), "b3f4:4994:c9e8:b21a:c493:e923:f711:1115" },
                 { aNewIsbnRandomizer(SEED), "9781797845005" },
                 { aNewLastNameRandomizer(SEED), "Durgan" },
                 { aNewLatitudeRandomizer(SEED), "40" + new DecimalFormatSymbols().getDecimalSeparator() + "171357" },
                 { aNewLongitudeRandomizer(SEED), "80" + new DecimalFormatSymbols().getDecimalSeparator() + "342713" },
+                { aNewMacAddressRandomizer(SEED), "b3:f4:49:94:c9:e8" },
                 { aNewParagraphRandomizer(SEED), "Totam assumenda eius autem similique. Aut voluptatem enim praesentium. Suscipit cupiditate doloribus debitis dolor. Cumque sapiente occaecati. Quos maiores quae." },
                 { aNewPhoneNumberRandomizer(SEED), "1-069-574-7539" },
                 { aNewRegularExpressionRandomizer("\\d+[A-Z]{5}", SEED), "8UYSMT" },
@@ -128,10 +137,13 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
                 { aNewEmailRandomizer(SEED, LOCALE), "alice.masson@hotmail.fr" }, 
                 { aNewFirstNameRandomizer(SEED, LOCALE), "Alice" },
                 { aNewFullNameRandomizer(SEED, LOCALE), "Masson Emilie" },
+                { aNewIpv4AddressRandomizer(SEED, LOCALE), "16.188.76.229" },
+                { aNewIpv6AddressRandomizer(SEED, LOCALE), "b3f4:4994:c9e8:b21a:c493:e923:f711:1115" },
                 { aNewIsbnRandomizer(SEED, LOCALE), "9781797845005" },
                 { aNewLastNameRandomizer(SEED, LOCALE), "Faure" },
                 { aNewLatitudeRandomizer(SEED, LOCALE), "40" + new DecimalFormatSymbols().getDecimalSeparator() + "171357" }, // should really be "40.171357", seems like a bug in java-faker
                 { aNewLongitudeRandomizer(SEED, LOCALE), "80" + new DecimalFormatSymbols().getDecimalSeparator() + "342713" }, // should really be "80.342713", seems like a bug in java-faker
+                { aNewMacAddressRandomizer(SEED, LOCALE), "b3:f4:49:94:c9:e8" },
                 { aNewParagraphRandomizer(SEED, LOCALE), "Totam assumenda eius autem similique. Aut voluptatem enim praesentium. Suscipit cupiditate doloribus debitis dolor. Cumque sapiente occaecati. Quos maiores quae." },
                 { aNewPhoneNumberRandomizer(SEED, LOCALE), "03 06 95 74 75" },
                 { aNewSentenceRandomizer(SEED, LOCALE), "Dolor totam assumenda eius autem." },


### PR DESCRIPTION
Add some common randomizers provided by JavaFaker.

Also changed implementation of FakerBasedRandomizer so it can be extended from outside.