### PR TITLE
Fix major performance regression.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ If you have any question, suggestion, or feedback, do not hesitate to use the [G
 * [Jose Manuel Prieto](https://github.com/prietopa)
 * [kermit-the-frog](https://github.com/kermit-the-frog)
 * [Lucas Andersson](https://github.com/LucasAndersson)
+* [Michael Düsterhus](https://github.com/reitzmichnicht)
 * [Nikola Milivojevic](https://github.com/dziga)
 * [Oleksandr Shcherbyna](https://github.com/sansherbina)
 * [Petromir Dzhunev](https://github.com/petromir)

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/SizeAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/SizeAnnotationHandler.java
@@ -62,7 +62,7 @@ class SizeAnnotationHandler implements BeanValidationAnnotationHandler {
                 .getAnnotation(field, Size.class);
 
         final int min = sizeAnnotation.min();
-        final int max = sizeAnnotation.max();
+        final int max = sizeAnnotation.max() == Integer.MAX_VALUE ? 255 : sizeAnnotation.max();
         if (easyRandom == null) {
             EasyRandomParameters parameters = new EasyRandomParameters()
                     .seed(this.seed)

--- a/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationAnnotatedBean.java
+++ b/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationAnnotatedBean.java
@@ -115,6 +115,9 @@ class BeanValidationAnnotatedBean {
     @Size(min=2, max=10)
     private String[] sizedArray;
 
+    @Size(min=2)
+    private String sizedString;
+
     @Pattern(regexp="[a-z]{4}")
     private String regexString;
 

--- a/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationMethodAnnotatedBean.java
+++ b/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationMethodAnnotatedBean.java
@@ -81,6 +81,8 @@ class BeanValidationMethodAnnotatedBean {
 
     private String[] sizedArray;
 
+    private String sizedString;
+
     private String regexString;
 
     @AssertFalse
@@ -337,6 +339,15 @@ class BeanValidationMethodAnnotatedBean {
         this.sizedArray = sizedArray;
     }
 
+    @Size(min=2)
+    public String getSizedString() {
+        return sizedString;
+    }
+
+    public void setSizedString(String sizedString) {
+        this.sizedString = sizedString;
+    }
+
     @Override
     public String toString() {
         return "BeanValidationMethodAnnotatedBean{" +
@@ -367,6 +378,7 @@ class BeanValidationMethodAnnotatedBean {
                 ", sizedSet=" + sizedSet +
                 ", sizedMap=" + sizedMap +
                 ", sizedArray=" + Arrays.toString(sizedArray) +
+                ", sizedString=" + sizedString +
                 ", regexString='" + regexString + '\'' +
                 '}';
     }

--- a/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationTest.java
+++ b/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationTest.java
@@ -167,6 +167,7 @@ public class BeanValidationTest {
         assertThat(bean.getSizedSet().size()).isBetween(2, 10);// @Size(min=2, max=10) String sizedSet;
         assertThat(bean.getSizedMap().size()).isBetween(2, 10);// @Size(min=2, max=10) String sizedMap;
         assertThat(bean.getSizedArray().length).isBetween(2, 10);// @Size(min=2, max=10) String sizedArray;
+        assertThat(bean.getSizedString().length()).isBetween(2, 255);// @Size(min=2) String sizedString;
 
         assertThat(bean.getRegexString()).matches("[a-z]{4}");
     }

--- a/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationTest.java
+++ b/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationTest.java
@@ -106,6 +106,7 @@ public class BeanValidationTest {
         assertThat(bean.getSizedSet().size()).isBetween(2, 10);// @Size(min=2, max=10) String sizedSet;
         assertThat(bean.getSizedMap().size()).isBetween(2, 10);// @Size(min=2, max=10) String sizedMap;
         assertThat(bean.getSizedArray().length).isBetween(2, 10);// @Size(min=2, max=10) String sizedArray;
+        assertThat(bean.getSizedString().length()).isBetween(2, 255);// @Size(min=2) String sizedString;
 
         assertThat(bean.getRegexString()).matches("[a-z]{4}");
     }


### PR DESCRIPTION
Limit Size max annotation to 255 if undefined.
This is the same behavior as JPA does interpret this annotation.