### PR TITLE
Compile pattern before creating predicate

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/FieldPredicates.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/FieldPredicates.java
@@ -46,8 +46,10 @@ public class FieldPredicates {
      * @param name pattern of the field name to check
      * @return Predicate to check that a field has a certain name pattern
      */
-    public static Predicate<Field> named(final String name) {
-        return field -> Pattern.compile(name).matcher(field.getName()).matches();
+    public static Predicate<Field> named(final String name)
+    {
+        final Pattern pattern = Pattern.compile(name);
+        return field -> pattern.matcher(field.getName()).matches();
     }
 
     /**

--- a/easy-random-core/src/main/java/org/jeasy/random/FieldPredicates.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/FieldPredicates.java
@@ -46,8 +46,7 @@ public class FieldPredicates {
      * @param name pattern of the field name to check
      * @return Predicate to check that a field has a certain name pattern
      */
-    public static Predicate<Field> named(final String name)
-    {
+    public static Predicate<Field> named(final String name) {
         final Pattern pattern = Pattern.compile(name);
         return field -> pattern.matcher(field.getName()).matches();
     }


### PR DESCRIPTION
The method FieldPredicates.named(string) has a major performance issue. The predicate compiles the name to regex pattern inside the test method. This makes it extremely slow when creating a large number of randomized objects.

Pattern is immutable and thread-safe and can be compiled before creating the predicate. This reduces execution time a lot and also saves quite some memory garbage.