### PR TITLE
Configurable temporal unit in DurationRandomizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ If you have any question, suggestion, or feedback, do not hesitate to use the [G
 * [Valters Vingolds](https://github.com/valters)
 * [Vincent Potucek](https://github.com/punkratz312)
 * [Weronika Redlarska](https://github.com/weronika-redlarska)
+* [Konstantin Lutovich](https://github.com/lutovich)
 
 Thank you all for your contributions!
 

--- a/easy-random-core/src/main/java/org/jeasy/random/randomizers/time/DurationRandomizer.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/randomizers/time/DurationRandomizer.java
@@ -28,6 +28,7 @@ import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 
 /**
  * A {@link Randomizer} that generates random {@link Duration}.
@@ -40,25 +41,53 @@ public class DurationRandomizer implements Randomizer<Duration> {
     private static final int MAX_AMOUNT = 100;
 
     private final IntegerRangeRandomizer amountRandomizer;
+    private final TemporalUnit unit;
 
     /**
      * Create a new {@link DurationRandomizer}.
+     * Generated {@link Duration} objects will use {@link ChronoUnit#HOURS}.
      */
     public DurationRandomizer() {
-        amountRandomizer = new IntegerRangeRandomizer(MIN_AMOUNT, MAX_AMOUNT);
+        this(ChronoUnit.HOURS);
+    }
+
+    /**
+     * Create a new {@link DurationRandomizer}.
+     *
+     * @param unit the temporal unit for created durations
+     */
+    public DurationRandomizer(final TemporalUnit unit) {
+        this(new IntegerRangeRandomizer(MIN_AMOUNT, MAX_AMOUNT), unit);
+    }
+
+    /**
+     * Create a new {@link DurationRandomizer}.
+     * Generated {@link Duration} objects will use {@link ChronoUnit#HOURS}.
+     *
+     * @param seed initial seed
+     */
+    public DurationRandomizer(final long seed) {
+        this(seed, ChronoUnit.HOURS);
     }
 
     /**
      * Create a new {@link DurationRandomizer}.
      *
      * @param seed initial seed
+     * @param unit the temporal unit for created durations
      */
-    public DurationRandomizer(final long seed) {
-        amountRandomizer = new IntegerRangeRandomizer(MIN_AMOUNT, MAX_AMOUNT, seed);
+    public DurationRandomizer(final long seed, final TemporalUnit unit) {
+        this(new IntegerRangeRandomizer(MIN_AMOUNT, MAX_AMOUNT, seed), unit);
+    }
+
+    private DurationRandomizer(final IntegerRangeRandomizer amountRandomizer, final TemporalUnit unit) {
+        this.amountRandomizer = amountRandomizer;
+        this.unit = requireValid(unit);
     }
 
     /**
      * Create a new {@link DurationRandomizer}.
+     * Generated {@link Duration} objects will use {@link ChronoUnit#HOURS}.
      *
      * @return a new {@link DurationRandomizer}.
      */
@@ -69,6 +98,17 @@ public class DurationRandomizer implements Randomizer<Duration> {
     /**
      * Create a new {@link DurationRandomizer}.
      *
+     * @param unit the temporal unit for created durations
+     * @return a new {@link DurationRandomizer}.
+     */
+    public static DurationRandomizer aNewDurationRandomizer(TemporalUnit unit) {
+        return new DurationRandomizer(unit);
+    }
+
+    /**
+     * Create a new {@link DurationRandomizer}.
+     * Generated {@link Duration} objects will use {@link ChronoUnit#HOURS}.
+     *
      * @param seed initial seed
      * @return a new {@link DurationRandomizer}.
      */
@@ -76,10 +116,27 @@ public class DurationRandomizer implements Randomizer<Duration> {
         return new DurationRandomizer(seed);
     }
 
+    /**
+     * Create a new {@link DurationRandomizer}.
+     *
+     * @param seed initial seed
+     * @param unit the temporal unit for created durations
+     * @return a new {@link DurationRandomizer}.
+     */
+    public static DurationRandomizer aNewDurationRandomizer(final long seed, final TemporalUnit unit) {
+        return new DurationRandomizer(seed, unit);
+    }
+
     @Override
     public Duration getRandomValue() {
         int randomAmount = amountRandomizer.getRandomValue();
-        return Duration.of(randomAmount, ChronoUnit.HOURS);
+        return Duration.of(randomAmount, unit);
     }
 
+    private static TemporalUnit requireValid(TemporalUnit unit) {
+        if (unit.isDurationEstimated() && unit != ChronoUnit.DAYS) {
+            throw new IllegalArgumentException("Temporal unit " + unit + " can't be used to create Duration objects");
+        }
+        return unit;
+    }
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/randomizers/time/TimeRandomizersTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/randomizers/time/TimeRandomizersTest.java
@@ -23,6 +23,7 @@
  */
 package org.jeasy.random.randomizers.time;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.jeasy.random.randomizers.time.CalendarRandomizer.aNewCalendarRandomizer;
 import static org.jeasy.random.randomizers.time.DateRandomizer.aNewDateRandomizer;
 import static org.jeasy.random.randomizers.time.DurationRandomizer.aNewDurationRandomizer;
@@ -43,6 +44,7 @@ import static org.jeasy.random.randomizers.time.YearRandomizer.aNewYearRandomize
 import static org.jeasy.random.randomizers.time.ZoneOffsetRandomizer.aNewZoneOffsetRandomizer;
 import static java.time.LocalDateTime.of;
 import static java.time.ZoneOffset.ofTotalSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import java.sql.Time;
@@ -65,6 +67,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -114,6 +117,8 @@ class TimeRandomizersTest extends AbstractRandomizerTest<Randomizer<?>> {
 
         return new Object[][] {
                 { aNewDurationRandomizer(SEED), Duration.of(72L, ChronoUnit.HOURS) },
+                { aNewDurationRandomizer(SEED, ChronoUnit.MINUTES), Duration.of(72L, ChronoUnit.MINUTES) },
+                { aNewDurationRandomizer(SEED, ChronoUnit.MILLIS), Duration.of(72L, ChronoUnit.MILLIS) },
                 { aNewLocalDateRandomizer(SEED), LocalDate.of(2024, Month.MARCH, 20) },
                 { aNewMonthDayRandomizer(SEED), MonthDay.of(Month.MARCH, 20) },
                 { aNewLocalTimeRandomizer(SEED), LocalTime.of(16, 42, 58) },
@@ -141,5 +146,29 @@ class TimeRandomizersTest extends AbstractRandomizerTest<Randomizer<?>> {
         Object actual = randomizer.getRandomValue();
 
         then(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAllowToCreateDurationRandomizerWithSuitableTemporalUnits() {
+        assertThat(aNewDurationRandomizer(ChronoUnit.NANOS).getRandomValue()).isGreaterThanOrEqualTo(Duration.ZERO);
+        assertThat(aNewDurationRandomizer(ChronoUnit.MICROS).getRandomValue()).isGreaterThanOrEqualTo(Duration.ZERO);
+        assertThat(aNewDurationRandomizer(ChronoUnit.MILLIS).getRandomValue()).isGreaterThanOrEqualTo(Duration.ZERO);
+        assertThat(aNewDurationRandomizer(ChronoUnit.SECONDS).getRandomValue()).isGreaterThanOrEqualTo(Duration.ZERO);
+        assertThat(aNewDurationRandomizer(ChronoUnit.MINUTES).getRandomValue()).isGreaterThanOrEqualTo(Duration.ZERO);
+        assertThat(aNewDurationRandomizer(ChronoUnit.HOURS).getRandomValue()).isGreaterThanOrEqualTo(Duration.ZERO);
+        assertThat(aNewDurationRandomizer(ChronoUnit.HALF_DAYS).getRandomValue()).isGreaterThanOrEqualTo(Duration.ZERO);
+        assertThat(aNewDurationRandomizer(ChronoUnit.DAYS).getRandomValue()).isGreaterThanOrEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void shouldDisallowToCreateDurationRandomizerWithEstimatedTemporalUnits() {
+        assertThatThrownBy(() -> aNewDurationRandomizer(ChronoUnit.WEEKS)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> aNewDurationRandomizer(ChronoUnit.MONTHS)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> aNewDurationRandomizer(ChronoUnit.YEARS)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> aNewDurationRandomizer(ChronoUnit.DECADES)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> aNewDurationRandomizer(ChronoUnit.CENTURIES)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> aNewDurationRandomizer(ChronoUnit.MILLENNIA)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> aNewDurationRandomizer(ChronoUnit.ERAS)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> aNewDurationRandomizer(ChronoUnit.FOREVER)).isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
This change makes it possible to create a `DurationRandomizer` that generates durations of the specified `TemporalUnit`. When not configured, the default unit is hours.