### PR TITLE
Removed fields for date and time

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/randomizers/range/LocalDateTimeRangeRandomizer.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/randomizers/range/LocalDateTimeRangeRandomizer.java
@@ -1,32 +1,36 @@
 /**
  * The MIT License
- * <p>
- * Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
- * <p>
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * <p>
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * <p>
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ *
+ *   Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
  */
 package org.jeasy.random.randomizers.range;
 
+import org.jeasy.random.EasyRandomParameters;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.zone.ZoneRules;
 
 /**
  * Generate a random {@link LocalDateTime} in the given range.
@@ -98,18 +102,16 @@ public class LocalDateTimeRangeRandomizer extends AbstractRangeRandomizer<LocalD
 
     @Override
     public LocalDateTime getRandomValue() {
-        ZoneId zoneId = ZoneId.systemDefault();
-        ZoneOffset minOffset = zoneId.getRules()
-                                     .getOffset(min);
-        ZoneOffset maxOffset = zoneId.getRules()
-                                     .getOffset(max);
-        long minSeconds = min.toEpochSecond(minOffset);
-        long maxSeconds = max.toEpochSecond(maxOffset);
+
+        long minSeconds = min.toEpochSecond(ZoneOffset.UTC);
+        long maxSeconds = max.toEpochSecond(ZoneOffset.UTC);
         long seconds = (long) nextDouble(minSeconds, maxSeconds);
+        int minNanoSeconds = min.getNano();
+        int maxNanoSeconds = max.getNano();
+        long nanoSeconds = (long) nextDouble(minNanoSeconds, maxNanoSeconds);
+        Instant instant = Instant.ofEpochSecond(seconds, nanoSeconds);
 
-        Instant instant = Instant.ofEpochSecond(seconds);
-
-        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
     }
 
 }

--- a/easy-random-core/src/main/java/org/jeasy/random/randomizers/range/LocalDateTimeRangeRandomizer.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/randomizers/range/LocalDateTimeRangeRandomizer.java
@@ -1,31 +1,32 @@
 /**
  * The MIT License
- *
- *   Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
- *
- *   Permission is hereby granted, free of charge, to any person obtaining a copy
- *   of this software and associated documentation files (the "Software"), to deal
- *   in the Software without restriction, including without limitation the rights
- *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *   copies of the Software, and to permit persons to whom the Software is
- *   furnished to do so, subject to the following conditions:
- *
- *   The above copyright notice and this permission notice shall be included in
- *   all copies or substantial portions of the Software.
- *
- *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *   THE SOFTWARE.
+ * <p>
+ * Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 package org.jeasy.random.randomizers.range;
 
-import java.time.LocalDate;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 
 /**
  * Generate a random {@link LocalDateTime} in the given range.
@@ -33,10 +34,6 @@ import java.time.LocalTime;
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
 public class LocalDateTimeRangeRandomizer extends AbstractRangeRandomizer<LocalDateTime> {
-
-    private final LocalDateRangeRandomizer localDateRangeRandomizer;
-
-    private final LocalTimeRangeRandomizer localTimeRangeRandomizer;
 
     /**
      * Create a new {@link LocalDateTimeRangeRandomizer}.
@@ -46,8 +43,6 @@ public class LocalDateTimeRangeRandomizer extends AbstractRangeRandomizer<LocalD
      */
     public LocalDateTimeRangeRandomizer(final LocalDateTime min, final LocalDateTime max) {
         super(min, max);
-        localDateRangeRandomizer = new LocalDateRangeRandomizer(this.min.toLocalDate(), this.max.toLocalDate());
-        localTimeRangeRandomizer = new LocalTimeRangeRandomizer(this.min.toLocalTime(), this.max.toLocalTime());
     }
 
     /**
@@ -59,8 +54,6 @@ public class LocalDateTimeRangeRandomizer extends AbstractRangeRandomizer<LocalD
      */
     public LocalDateTimeRangeRandomizer(final LocalDateTime min, final LocalDateTime max, final long seed) {
         super(min, max, seed);
-        localDateRangeRandomizer = new LocalDateRangeRandomizer(this.min.toLocalDate(), this.max.toLocalDate(), seed);
-        localTimeRangeRandomizer = new LocalTimeRangeRandomizer(this.min.toLocalTime(), this.max.toLocalTime(), seed);
     }
 
     /**
@@ -105,9 +98,18 @@ public class LocalDateTimeRangeRandomizer extends AbstractRangeRandomizer<LocalD
 
     @Override
     public LocalDateTime getRandomValue() {
-        LocalDate randomLocalDate = localDateRangeRandomizer.getRandomValue();
-        LocalTime randomLocalTime = localTimeRangeRandomizer.getRandomValue();
-        return LocalDateTime.of(randomLocalDate, randomLocalTime);
+        ZoneId zoneId = ZoneId.systemDefault();
+        ZoneOffset minOffset = zoneId.getRules()
+                                     .getOffset(min);
+        ZoneOffset maxOffset = zoneId.getRules()
+                                     .getOffset(max);
+        long minSeconds = min.toEpochSecond(minOffset);
+        long maxSeconds = max.toEpochSecond(maxOffset);
+        long seconds = (long) nextDouble(minSeconds, maxSeconds);
+
+        Instant instant = Instant.ofEpochSecond(seconds);
+
+        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
     }
 
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/randomizers/range/LocalDateTimeRangeRandomizerTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/randomizers/range/LocalDateTimeRangeRandomizerTest.java
@@ -1,38 +1,36 @@
 /**
  * The MIT License
- *
- *   Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
- *
- *   Permission is hereby granted, free of charge, to any person obtaining a copy
- *   of this software and associated documentation files (the "Software"), to deal
- *   in the Software without restriction, including without limitation the rights
- *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *   copies of the Software, and to permit persons to whom the Software is
- *   furnished to do so, subject to the following conditions:
- *
- *   The above copyright notice and this permission notice shall be included in
- *   all copies or substantial portions of the Software.
- *
- *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *   THE SOFTWARE.
+ * <p>
+ * Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 package org.jeasy.random.randomizers.range;
 
-import static org.jeasy.random.randomizers.range.LocalDateTimeRangeRandomizer.aNewLocalDateTimeRangeRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.jeasy.random.randomizers.range.LocalDateTimeRangeRandomizer.aNewLocalDateTimeRangeRandomizer;
 
 class LocalDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTest<LocalDateTime> {
 
@@ -57,9 +55,10 @@ class LocalDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTest<Local
 
     @Test
     void generatedLocalDateTimeShouldBeAlwaysTheSameForTheSameSeed() {
+
         // Given
         randomizer = aNewLocalDateTimeRangeRandomizer(minDateTime, maxDateTime, SEED);
-        LocalDateTime expected = LocalDateTime.parse("+446348406-04-09T17:28:52");
+        LocalDateTime expected = LocalDateTime.parse("+446348406-04-09T16:32:16.990898895");
 
         // When
         LocalDateTime randomValue = randomizer.getRandomValue();
@@ -96,6 +95,7 @@ class LocalDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTest<Local
         // Then
         assertThat(randomValue).isAfterOrEqualTo(minDateTime);
     }
+
     @Test
     void whenMaxDateIsAfterMidnight_thenShouldNotThrowException() {
         minDateTime = LocalDateTime.parse("2019-10-21T23:33:44");

--- a/easy-random-core/src/test/java/org/jeasy/random/randomizers/range/LocalDateTimeRangeRandomizerTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/randomizers/range/LocalDateTimeRangeRandomizerTest.java
@@ -59,7 +59,7 @@ class LocalDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTest<Local
     void generatedLocalDateTimeShouldBeAlwaysTheSameForTheSameSeed() {
         // Given
         randomizer = aNewLocalDateTimeRangeRandomizer(minDateTime, maxDateTime, SEED);
-        LocalDateTime expected = LocalDateTime.of(LocalDate.ofEpochDay(163024688248L), LocalTime.ofSecondOfDay(62481));
+        LocalDateTime expected = LocalDateTime.parse("+446348406-04-09T17:28:52");
 
         // When
         LocalDateTime randomValue = randomizer.getRandomValue();
@@ -95,6 +95,20 @@ class LocalDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTest<Local
 
         // Then
         assertThat(randomValue).isAfterOrEqualTo(minDateTime);
+    }
+    @Test
+    void whenMaxDateIsAfterMidnight_thenShouldNotThrowException() {
+        minDateTime = LocalDateTime.parse("2019-10-21T23:33:44");
+        maxDateTime = LocalDateTime.parse("2019-10-22T00:33:22");
+
+        // Given
+        randomizer = aNewLocalDateTimeRangeRandomizer(minDateTime, maxDateTime);
+
+        // when
+        LocalDateTime randomValue = randomizer.getRandomValue();
+
+        // Then
+        assertThat(randomValue).isBetween(minDateTime, maxDateTime);
     }
 
 }


### PR DESCRIPTION
The randomizer could not generate datetime if the range span midnight, since the min/max-check failed for the LocalTimeRangeRandomizer.
The new implementation breaks the current seed-based generation.

#361 