### PR TITLE
Collections are always generated with the same size #387

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/CollectionPopulator.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/CollectionPopulator.java
@@ -40,14 +40,17 @@ import static org.jeasy.random.util.ReflectionUtils.*;
 class CollectionPopulator {
 
     private final EasyRandom easyRandom;
+    private final IntegerRangeRandomizer integerRangeRandomizer;
 
-    CollectionPopulator(final EasyRandom easyRandom) {
+    CollectionPopulator(final EasyRandom easyRandom, EasyRandomParameters parameters) {
         this.easyRandom = easyRandom;
+        EasyRandomParameters.Range<Integer> collectionSizeRange = parameters.getCollectionSizeRange();
+        integerRangeRandomizer = new IntegerRangeRandomizer(collectionSizeRange.getMin(), collectionSizeRange.getMax(), parameters.getSeed());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     Collection<?> getRandomCollection(final Field field, final RandomizationContext context) {
-        int randomSize = getRandomCollectionSize(context.getParameters());
+        int randomSize = getRandomCollectionSize();
         Class<?> fieldType = field.getType();
         Type fieldGenericType = field.getGenericType();
         Collection collection;
@@ -73,8 +76,7 @@ class CollectionPopulator {
 
     }
 
-    private int getRandomCollectionSize(EasyRandomParameters parameters) {
-        EasyRandomParameters.Range<Integer> collectionSizeRange = parameters.getCollectionSizeRange();
-        return new IntegerRangeRandomizer(collectionSizeRange.getMin(), collectionSizeRange.getMax(), parameters.getSeed()).getRandomValue();
+    private int getRandomCollectionSize() {
+        return integerRangeRandomizer.getRandomValue();
     }
 }

--- a/easy-random-core/src/main/java/org/jeasy/random/EasyRandom.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/EasyRandom.java
@@ -77,7 +77,7 @@ public class EasyRandom extends Random {
         randomizerProvider.setRandomizerRegistries(registries);
         objectFactory = easyRandomParameters.getObjectFactory();
         arrayPopulator = new ArrayPopulator(this);
-        CollectionPopulator collectionPopulator = new CollectionPopulator(this);
+        CollectionPopulator collectionPopulator = new CollectionPopulator(this, easyRandomParameters);
         MapPopulator mapPopulator = new MapPopulator(this, objectFactory);
         enumRandomizersByType = new ConcurrentHashMap<>();
         fieldPopulator = new FieldPopulator(this, this.randomizerProvider, arrayPopulator, collectionPopulator, mapPopulator);

--- a/easy-random-core/src/test/java/org/jeasy/random/CollectionPopulatorTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/CollectionPopulatorTest.java
@@ -33,9 +33,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.DelayQueue;
-import java.util.concurrent.SynchronousQueue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +68,7 @@ class CollectionPopulatorTest {
     @BeforeEach
     void setUp() {
         parameters = new EasyRandomParameters().collectionSizeRange(SIZE, SIZE);
-        collectionPopulator = new CollectionPopulator(easyRandom);
+        collectionPopulator = new CollectionPopulator(easyRandom, parameters);
     }
 
     /*
@@ -80,7 +77,6 @@ class CollectionPopulatorTest {
     @Test
     void rawInterfaceCollectionTypesMustBeReturnedEmpty() throws Exception {
         // Given
-        when(context.getParameters()).thenReturn(parameters);
         Field field = Foo.class.getDeclaredField("rawInterfaceList");
 
         // When
@@ -93,7 +89,6 @@ class CollectionPopulatorTest {
     @Test
     void rawConcreteCollectionTypesMustBeReturnedEmpty() throws Exception {
         // Given
-        when(context.getParameters()).thenReturn(parameters);
         Field field = Foo.class.getDeclaredField("rawConcreteList");
 
         // When
@@ -106,7 +101,6 @@ class CollectionPopulatorTest {
     @Test
     void typedInterfaceCollectionTypesMightBePopulated() throws Exception {
         // Given
-        when(context.getParameters()).thenReturn(parameters);
         when(easyRandom.doPopulateBean(String.class, context)).thenReturn(STRING);
         Field field = Foo.class.getDeclaredField("typedInterfaceList");
 
@@ -121,7 +115,6 @@ class CollectionPopulatorTest {
     @Test
     void typedConcreteCollectionTypesMightBePopulated() throws Exception {
         // Given
-        when(context.getParameters()).thenReturn(parameters);
         when(easyRandom.doPopulateBean(String.class, context)).thenReturn(STRING);
         Field field = Foo.class.getDeclaredField("typedConcreteList");
 

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -34,10 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Modifier;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static java.sql.Timestamp.valueOf;
@@ -278,14 +275,33 @@ class EasyRandomTest {
     }
 
     @Test
-    void generateCollectionsOfDifferentSize() {
+    void generateCollectionsOfDifferentSize_whenReusingEasyRandomInstance() {
         Set<Integer> collectionsSizes = new HashSet<>();
+        EasyRandom easyRandom = new EasyRandom();
         for (int i = 0; i < 100; i++) {
-            final SomeClass someClass = new EasyRandom().nextObject(SomeClass.class);
+            final SomeClass someClass = easyRandom.nextObject(SomeClass.class);
             collectionsSizes.add(someClass.lorem.size());
         }
 
         assertThat(collectionsSizes.size()).isGreaterThan(1);
+    }
+
+    @Test
+    void collectionSizesAreRepeatable_whenFixedSeedIsUsed() {
+        long seed = new Random().nextInt();
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        parameters.seed(seed);
+        EasyRandom first = new EasyRandom(parameters);
+        EasyRandom second = new EasyRandom(parameters);
+        List<Integer> firstResult = new ArrayList<>();
+        List<Integer> secondResult = new ArrayList<>();
+
+        for(int i = 0; i<100; i++) {
+            firstResult.add(first.nextObject(SomeClass.class).lorem.size());
+            secondResult.add(second.nextObject(SomeClass.class).lorem.size());
+        }
+
+        assertThat(firstResult).isEqualTo(secondResult);
     }
 }
 

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -37,6 +37,7 @@ import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.sql.Timestamp.valueOf;
@@ -276,4 +277,20 @@ class EasyRandomTest {
         System.out.println("Failure: " + failure);
     }
 
+    @Test
+    void generateCollectionsOfDifferentSize() {
+        Set<Integer> collectionsSizes = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            final SomeClass someClass = new EasyRandom().nextObject(SomeClass.class);
+            collectionsSizes.add(someClass.lorem.size());
+        }
+
+        assertThat(collectionsSizes.size()).isGreaterThan(1);
+    }
+}
+
+class SomeClass {
+    int number;
+    String text;
+    List<String> lorem;
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/parameters/SeedParameterTests.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/parameters/SeedParameterTests.java
@@ -25,72 +25,58 @@ package org.jeasy.random.parameters;
 
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
-import org.jeasy.random.beans.Address;
-import org.jeasy.random.beans.Gender;
 import org.jeasy.random.beans.Person;
-import org.jeasy.random.beans.Street;
 import org.junit.jupiter.api.Test;
+
+import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SeedParameterTests {
 
-    private static final long SEED = 123L;
+    private EasyRandomParameters parameters = new EasyRandomParameters().seed((long) new Random().nextInt());
+    private EasyRandom randomA = new EasyRandom(parameters);
+    private EasyRandom randomB = new EasyRandom(parameters);
 
     @Test
-    void generatedObjectShouldBeAlwaysTheSameForTheSameSeed() {
-        // Given
-        EasyRandomParameters parameters = new EasyRandomParameters().seed(SEED);
-        EasyRandom easyRandom = new EasyRandom(parameters);
+    void generated_String_ShouldBeAlwaysTheSameForTheSameSeed() {
+        //when
+        String firstStringA = randomA.nextObject(String.class);
+        String firstStringB = randomB.nextObject(String.class);
+        String secondStringA = randomA.nextObject(String.class);
+        String secondStringB = randomB.nextObject(String.class);
 
-        String expectedString = "eOMtThyhVNLWUZNRcBaQKxI";
-        Person expectedPerson = buildExpectedPerson();
-        int[] expectedInts = buildExpectedInts();
-
-        // When
-        String actualString = easyRandom.nextObject(String.class);
-        Person actualPerson = easyRandom.nextObject(Person.class);
-        int[] actualInts = easyRandom.nextObject(int[].class);
-
-        // Then
-        assertThat(actualString).isEqualTo(expectedString);
-        assertThat(actualPerson).isEqualToIgnoringNullFields(expectedPerson);
-        assertThat(actualInts).isEqualTo(expectedInts);
+        //then
+        assertThat(firstStringA).isEqualTo(firstStringB);
+        assertThat(firstStringA).isNotEqualTo(secondStringA);
+        assertThat(secondStringA).isEqualTo(secondStringB);
     }
 
-    private Person buildExpectedPerson() {
-        Person expectedPerson = new Person();
+    @Test
+    void generated_Bean_ShouldBeAlwaysTheSameForTheSameSeed() {
+        //when
+        Person firstBeanA = randomA.nextObject(Person.class);
+        Person firstBeanB = randomB.nextObject(Person.class);
+        Person secondBeanA = randomA.nextObject(Person.class);
+        Person secondBeanB = randomB.nextObject(Person.class);
 
-        Street street = new Street();
-        street.setName("JxkyvRnL");
-        street.setNumber(-1188957731);
-        street.setType((byte) -35);
-
-        Address address = new Address();
-        address.setCity("VLhpfQGTMDYpsBZxvfBoeygjb");
-        address.setCountry("UMaAIKKIkknjWEXJUfPxxQHeWKEJ");
-        address.setZipCode("RYtGKbgicZaHCBRQDSx");
-        address.setStreet(street);
-
-        expectedPerson.setName("B");
-        expectedPerson.setEmail("yedUsFwdkelQbxeTeQOvaScfqIOOmaa");
-        expectedPerson.setPhoneNumber("dpHYZGhtgdntugzvvKAXLhM");
-        expectedPerson.setGender(Gender.FEMALE);
-        expectedPerson.setAddress(address);
-
-        return expectedPerson;
+        //then
+        assertThat(firstBeanA).isEqualTo(firstBeanB);
+        assertThat(firstBeanA).isNotEqualTo(secondBeanA);
+        assertThat(secondBeanA).isEqualTo(secondBeanB);
     }
 
-    private int[] buildExpectedInts() {
-        return new int[]{
-                -535098017, -1935747844, -1219562352, 696711130, 308881275, -1366603797, -875052456, 1149563170, -1809396988,
-                1041944832, -394597452, -1708209621, 639583273, 930399700, -106429739, 1967925707, 281732816, 382363784,
-                298577043, 525072488, 389778123, 1452179944, 1823070661, -292028230, -539486391, -1383466546, -1824914989,
-                8083668, 1702941070, 2146898372, 1109455496, -82323612, 656237286, -851237395, 1118538028, -924378823,
-                1982908886, 61937700, 1885923537, 1007147781, 907979413, 2048182629, -1656946195, 610315108, 143700666,
-                1887585643, -1336180951, 481114396, -1356725194, -648969061, 323234679, 672907686, -228467837, 1719789600,
-                1876370794, -260807699, -1315052259, 1788269654, -1389857855, -736339116, -1594362319, -1447490197, -1826631868,
-                132343550, 1666325652, -964773309, 812299731, 1789518152, 114768374, 796275100, 135535291, -1663939686
-        };
+    @Test
+    void generated_Array_ShouldBeAlwaysTheSameForTheSameSeed() {
+        //when
+        int[] firstArrayA = randomA.nextObject(int[].class);
+        int[] firstArrayB = randomB.nextObject(int[].class);
+        int[] secondArrayA = randomA.nextObject(int[].class);
+        int[] secondArrayB = randomB.nextObject(int[].class);
+
+        //then
+        assertThat(firstArrayA).isEqualTo(firstArrayB);
+        assertThat(firstArrayA).isNotEqualTo(secondArrayA);
+        assertThat(secondArrayA).isEqualTo(secondArrayB);
     }
 }


### PR DESCRIPTION
https://github.com/j-easy/easy-random/issues/387

The solution is based on reusing the same instance of IntegerRangeRandomizer for generating collections size. Originally, a new instance of IntegerRangeRandomizer was created whenever a collection was populated, each time with the same seed value. As a consequence IntegerRangeRandomizer always generated the same value.

Presumably, the same solution should be applied to arrays.