### PR TITLE
Arrays are always generated with the same size

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/ArrayPopulator.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/ArrayPopulator.java
@@ -53,6 +53,6 @@ class ArrayPopulator {
 
     private int getRandomArraySize(EasyRandomParameters parameters) {
         EasyRandomParameters.Range<Integer> collectionSizeRange = parameters.getCollectionSizeRange();
-        return new IntegerRangeRandomizer(collectionSizeRange.getMin(), collectionSizeRange.getMax(), parameters.getSeed()).getRandomValue();
+        return new IntegerRangeRandomizer(collectionSizeRange.getMin(), collectionSizeRange.getMax(), easyRandom.nextLong()).getRandomValue();
     }
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -34,9 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Modifier;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static java.sql.Timestamp.valueOf;
@@ -291,4 +289,37 @@ class EasyRandomTest {
         System.out.println("Failure: " + failure);
     }
 
+    @Test
+    void generateArraysOfDifferentSize_whenReusingEasyRandomInstance() {
+        Set<Integer> collectionsSizes = new HashSet<>();
+        EasyRandom easyRandom = new EasyRandom();
+        for (int i = 0; i < 100; i++) {
+            final SomeClass someClass = easyRandom.nextObject(SomeClass.class);
+            collectionsSizes.add(someClass.array.length);
+        }
+
+        assertThat(collectionsSizes.size()).isGreaterThan(1);
+    }
+
+    @Test
+    void arraySizesAreRepeatable_whenFixedSeedIsUsed() {
+        long seed = new Random().nextInt();
+        EasyRandomParameters parameters = new EasyRandomParameters();
+        parameters.seed(seed);
+        EasyRandom first = new EasyRandom(parameters);
+        EasyRandom second = new EasyRandom(parameters);
+        List<Integer> firstResult = new ArrayList<>();
+        List<Integer> secondResult = new ArrayList<>();
+
+        for(int i = 0; i<100; i++) {
+            firstResult.add(first.nextObject(SomeClass.class).array.length);
+            secondResult.add(second.nextObject(SomeClass.class).array.length);
+        }
+
+        assertThat(firstResult).isEqualTo(secondResult);
+    }
+}
+
+class SomeClass {
+    String[] array;
 }


### PR DESCRIPTION
It solves the #387 issue for arrays. I applied the same solution as @benas did in https://github.com/j-easy/easy-random/pull/391 for collections.
The change caused the `generatedObjectShouldBeAlwaysTheSameForTheSameSeed` to fail. I fixed it in the same way as in PR 391 which raised there some controversy. I extracted from the test the flow regarding arrays to a new test where I generate arrays using the same seed and then assert the equality of the generated arrays. I could adapt the original test by changing the expected array, but such a solution is not clean in my opinion. The expected array is a magic value and it doesn't manifest the test intention. It compares generated array against the magic value whereas the goal is (unless I'm mistaken) to assure that reusing the seed leads to generating the same results.