### PR TITLE
#405 Parametrization of nested objects generation

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/ArrayPopulator.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/ArrayPopulator.java
@@ -42,7 +42,7 @@ class ArrayPopulator {
 
     Object getRandomArray(final Class<?> fieldType, final RandomizationContext context) {
         Class<?> componentType = fieldType.getComponentType();
-        int randomSize = getRandomArraySize(context.getParameters());
+        int randomSize = getRandomArraySize(context.getParameters(), context.useEmptyOnCurrentRandomizationDepth());
         Object result = Array.newInstance(componentType, randomSize);
         for (int i = 0; i < randomSize; i++) {
             Object randomElement = easyRandom.doPopulateBean(componentType, context);
@@ -51,8 +51,11 @@ class ArrayPopulator {
         return result;
     }
 
-    private int getRandomArraySize(EasyRandomParameters parameters) {
+    private int getRandomArraySize(EasyRandomParameters parameters, boolean hasReachedRandomizationDepth) {
         EasyRandomParameters.Range<Integer> collectionSizeRange = parameters.getCollectionSizeRange();
+        if (hasReachedRandomizationDepth) {
+            return 0;
+        }
         return new IntegerRangeRandomizer(collectionSizeRange.getMin(), collectionSizeRange.getMax(), easyRandom.nextLong()).getRandomValue();
     }
 }

--- a/easy-random-core/src/main/java/org/jeasy/random/CollectionPopulator.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/CollectionPopulator.java
@@ -58,7 +58,7 @@ class CollectionPopulator {
             collection = createEmptyCollectionForType(fieldType, randomSize);
         }
 
-        if (isParameterizedType(fieldGenericType)) { // populate only parametrized types, raw types will be empty
+        if (!context.useEmptyOnCurrentRandomizationDepth() && isParameterizedType(fieldGenericType)) { // populate only parametrized types, raw types will be empty
             ParameterizedType parameterizedType = (ParameterizedType) fieldGenericType;
             Type type = parameterizedType.getActualTypeArguments()[0];
             if (isPopulatable(type)) {

--- a/easy-random-core/src/main/java/org/jeasy/random/EasyRandomParameters.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/EasyRandomParameters.java
@@ -98,6 +98,7 @@ public class EasyRandomParameters {
     private boolean overrideDefaultInitialization;
     private boolean ignoreRandomizationErrors;
     private boolean bypassSetters;
+    private boolean avoidNullsOnDeepestRecursionLevel;
     private Range<Integer> collectionSizeRange;
     private Range<Integer> stringLengthRange;
     private Range<LocalDate> dateRange;
@@ -123,6 +124,7 @@ public class EasyRandomParameters {
         overrideDefaultInitialization = false;
         ignoreRandomizationErrors = false;
         bypassSetters = false;
+        avoidNullsOnDeepestRecursionLevel = true;
         objectPoolSize = DEFAULT_OBJECT_POOL_SIZE;
         randomizationDepth = DEFAULT_RANDOMIZATION_DEPTH;
         dateRange = new Range<>(DEFAULT_DATES_RANGE.getMin().toLocalDate(), DEFAULT_DATES_RANGE.getMax().toLocalDate());
@@ -228,6 +230,14 @@ public class EasyRandomParameters {
 
     public void setBypassSetters(boolean bypassSetters) {
         this.bypassSetters = bypassSetters;
+    }
+
+    public boolean isAvoidNullsOnDeepestRecursionLevel() {
+        return avoidNullsOnDeepestRecursionLevel;
+    }
+
+    public void setAvoidNullsOnDeepestRecursionLevel(boolean avoidNullsOnDeepestRecursionLevel) {
+        this.avoidNullsOnDeepestRecursionLevel = avoidNullsOnDeepestRecursionLevel;
     }
 
     public ExclusionPolicy getExclusionPolicy() {
@@ -557,6 +567,17 @@ public class EasyRandomParameters {
      */
     public EasyRandomParameters bypassSetters(boolean bypassSetters) {
         setBypassSetters(bypassSetters);
+        return this;
+    }
+
+    /**
+     * Flag to initialize fields with empty collections on the deepest level of recursive objects. True by default.
+     *
+     * @param avoidNullsOnDeepestRecursionLevel true if in place of nulls empty collections should be used
+     * @return the current {@link EasyRandomParameters} instance for method chaining
+     */
+    public EasyRandomParameters avoidNullsOnDeepestRecursionLevel(boolean avoidNullsOnDeepestRecursionLevel) {
+        setAvoidNullsOnDeepestRecursionLevel(avoidNullsOnDeepestRecursionLevel);
         return this;
     }
 

--- a/easy-random-core/src/main/java/org/jeasy/random/MapPopulator.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/MapPopulator.java
@@ -77,7 +77,7 @@ class MapPopulator {
             }
         }
 
-        if (isParameterizedType(fieldGenericType)) { // populate only parameterized types, raw types will be empty
+        if (!context.useEmptyOnCurrentRandomizationDepth() && isParameterizedType(fieldGenericType)) { // populate only parameterized types, raw types will be empty
             ParameterizedType parameterizedType = (ParameterizedType) fieldGenericType;
             Type keyType = parameterizedType.getActualTypeArguments()[0];
             Type valueType = parameterizedType.getActualTypeArguments()[1];

--- a/easy-random-core/src/main/java/org/jeasy/random/RandomizationContext.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/RandomizationContext.java
@@ -96,6 +96,11 @@ class RandomizationContext implements RandomizerContext {
         return currentRandomizationDepth > parameters.getRandomizationDepth();
     }
 
+    boolean useEmptyOnCurrentRandomizationDepth() {
+        int currentRandomizationDepth = stack.size();
+        return parameters.isAvoidNullsOnDeepestRecursionLevel() && currentRandomizationDepth == parameters.getRandomizationDepth();
+    }
+
     private List<String> getStackedFieldNames() {
         return stack.stream().map(i -> i.getField().getName()).collect(toList());
     }

--- a/easy-random-core/src/test/java/org/jeasy/random/RecursiveObject.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/RecursiveObject.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class RecursiveObject {
+    String field;
+    List<RecursiveObject> collection;
+    RecursiveObject[] array;
+    Map<String, RecursiveObject> map;
+
+    RecursiveObject(String field, ArrayList<RecursiveObject> collection, RecursiveObject[] array, Map<String, RecursiveObject> map) {
+        this.field = field == null ? "" : field;
+        this.collection = collection == null ? new ArrayList<>() : collection;
+        this.array = array == null ? new RecursiveObject[0] : array;
+        this.map = map == null ? new HashMap<>() : map;
+    }
+
+    List<RecursiveObject> flatten() {
+        ArrayList<RecursiveObject> result = new ArrayList<>();
+        result.add(this);
+        if (collection != null) {
+            result.addAll(flattenRecursively(collection.stream()));
+        }
+        if (array != null) {
+            result.addAll(flattenRecursively(Arrays.stream(array)));
+        }
+        if (map != null) {
+            result.addAll(flattenRecursively(map.values().stream()));
+        }
+        return result;
+    }
+
+    List<RecursiveObject> flattenRecursively(Stream<RecursiveObject> stream) {
+        return stream.flatMap(it -> it.flatten().stream()).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
It only partly solves #405. It addresses only the 1st scenario described there. I find the 2nd scenario less critical (as can be avoided by increasing the size of objects pool) and more challenging to implement.

The solution introduces a new parameter that is true by default. Hence, it changes the default behaviour which can be considered as a breaking change. The defaults can be easily inverted, but I believe that it is handy to have empty collections in place of nulls.