### PR TITLE
Make number-based validation annotation handlers support primitive wr…

### DIFF
--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/AbstractNumberBaseAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/AbstractNumberBaseAnnotationHandler.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random.validation;
+
+import org.jeasy.random.api.Randomizer;
+import org.jeasy.random.randomizers.range.*;
+import org.jeasy.random.randomizers.text.StringDelegatingRandomizer;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Random;
+
+/**
+ * @author dadiyang
+ * @since 2020/6/7
+ */
+public abstract class AbstractNumberBaseAnnotationHandler implements BeanValidationAnnotationHandler {
+    private final Random random;
+
+    AbstractNumberBaseAnnotationHandler(long seed) {
+        random = new Random(seed);
+    }
+
+    protected Randomizer<?> getRandomizer(Class<?> fieldType, BigDecimal maxValue, BigDecimal minValue) {
+        if (fieldType.equals(Byte.TYPE) || fieldType.equals(Byte.class)) {
+            return new ByteRangeRandomizer(
+                    minValue == null ? null : minValue.byteValue(),
+                    maxValue == null ? null : maxValue.byteValue(),
+                    random.nextLong()
+            );
+        }
+        if (fieldType.equals(Short.TYPE) || fieldType.equals(Short.class)) {
+            return new ShortRangeRandomizer(
+                    minValue == null ? null : minValue.shortValue(),
+                    maxValue == null ? null : maxValue.shortValue(),
+                    random.nextLong()
+            );
+        }
+        if (fieldType.equals(Integer.TYPE) || fieldType.equals(Integer.class)) {
+            return new IntegerRangeRandomizer(
+                    minValue == null ? null : minValue.intValue(),
+                    maxValue == null ? null : maxValue.intValue(),
+                    random.nextLong()
+            );
+        }
+        if (fieldType.equals(Long.TYPE) || fieldType.equals(Long.class)) {
+            return new LongRangeRandomizer(
+                    minValue == null ? null : minValue.longValue(),
+                    maxValue == null ? null : maxValue.longValue(),
+                    random.nextLong()
+            );
+        }
+        if (fieldType.equals(BigInteger.class)) {
+            return new BigIntegerRangeRandomizer(
+                    minValue == null ? null : minValue.intValue(),
+                    maxValue == null ? null : maxValue.intValue(),
+                    random.nextLong()
+            );
+        }
+        if (fieldType.equals(BigDecimal.class)) {
+            return new BigDecimalRangeRandomizer(
+                    minValue == null ? null : minValue.doubleValue(),
+                    maxValue == null ? null : maxValue.doubleValue(),
+                    random.nextLong()
+            );
+        }
+        if (fieldType.equals(String.class)) {
+            BigDecimalRangeRandomizer delegate = new BigDecimalRangeRandomizer(
+                    minValue == null ? null : minValue.doubleValue(),
+                    maxValue == null ? null : maxValue.doubleValue(),
+                    random.nextLong()
+            );
+            return new StringDelegatingRandomizer(delegate);
+        }
+        return null;
+    }
+
+}

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/DecimalMinMaxAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/DecimalMinMaxAnnotationHandler.java
@@ -24,23 +24,17 @@
 package org.jeasy.random.validation;
 
 import org.jeasy.random.api.Randomizer;
-import org.jeasy.random.randomizers.range.*;
-import org.jeasy.random.randomizers.text.StringDelegatingRandomizer;
 import org.jeasy.random.util.ReflectionUtils;
 
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Random;
 
-class DecimalMinMaxAnnotationHandler implements BeanValidationAnnotationHandler {
-
-    private final Random random;
+class DecimalMinMaxAnnotationHandler extends AbstractNumberBaseAnnotationHandler {
 
     DecimalMinMaxAnnotationHandler(long seed) {
-        random = new Random(seed);
+        super(seed);
     }
 
     @Override
@@ -61,57 +55,6 @@ class DecimalMinMaxAnnotationHandler implements BeanValidationAnnotationHandler 
         if (decimalMinAnnotation != null) {
             minValue = new BigDecimal(decimalMinAnnotation.value());
         }
-
-        if (fieldType.equals(Byte.TYPE) || fieldType.equals(Byte.class)) {
-            return new ByteRangeRandomizer(
-                    minValue == null ? null : minValue.byteValue(),
-                    maxValue == null ? null : maxValue.byteValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(Short.TYPE) || fieldType.equals(Short.class)) {
-            return new ShortRangeRandomizer(
-                    minValue == null ? null : minValue.shortValue(),
-                    maxValue == null ? null : maxValue.shortValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(Integer.TYPE) || fieldType.equals(Integer.class)) {
-            return new IntegerRangeRandomizer(
-                    minValue == null ? null : minValue.intValue(),
-                    maxValue == null ? null : maxValue.intValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(Long.TYPE) || fieldType.equals(Long.class)) {
-            return new LongRangeRandomizer(
-                    minValue == null ? null : minValue.longValue(),
-                    maxValue == null ? null : maxValue.longValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(BigInteger.class)) {
-            return new BigIntegerRangeRandomizer(
-                    minValue == null ? null : minValue.intValue(),
-                    maxValue == null ? null : maxValue.intValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(BigDecimal.class)) {
-            return new BigDecimalRangeRandomizer(
-                    minValue == null ? null : minValue.doubleValue(),
-                    maxValue == null ? null : maxValue.doubleValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(String.class)) {
-            BigDecimalRangeRandomizer delegate = new BigDecimalRangeRandomizer(
-                    minValue == null ? null : minValue.doubleValue(),
-                    maxValue == null ? null : maxValue.doubleValue(),
-                    random.nextLong()
-            );
-            return new StringDelegatingRandomizer(delegate);
-        }
-        return null;
+        return getRandomizer(fieldType, maxValue, minValue);
     }
 }

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/MinMaxAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/MinMaxAnnotationHandler.java
@@ -44,16 +44,16 @@ class MinMaxAnnotationHandler extends AbstractNumberBaseAnnotationHandler {
                 .getAnnotation(field, Max.class);
         Min minAnnotation = ReflectionUtils
                 .getAnnotation(field, Min.class);
-        Long maxValue = null;
-        Long minValue = null;
+        BigDecimal maxValue = null;
+        BigDecimal minValue = null;
 
         if (maxAnnotation != null) {
-            maxValue = maxAnnotation.value();
+            maxValue = new BigDecimal(maxAnnotation.value());
         }
 
         if (minAnnotation != null) {
-            minValue = minAnnotation.value();
+            minValue = new BigDecimal(minAnnotation.value());
         }
-        return getRandomizer(fieldType, new BigDecimal(String.valueOf(minValue)), new BigDecimal(String.valueOf(maxValue)));
+        return getRandomizer(fieldType, maxValue, minValue);
     }
 }

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/MinMaxAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/MinMaxAnnotationHandler.java
@@ -24,22 +24,17 @@
 package org.jeasy.random.validation;
 
 import org.jeasy.random.api.Randomizer;
-import org.jeasy.random.randomizers.range.*;
 import org.jeasy.random.util.ReflectionUtils;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Random;
 
-class MinMaxAnnotationHandler implements BeanValidationAnnotationHandler {
-
-    private final Random random;
+class MinMaxAnnotationHandler extends AbstractNumberBaseAnnotationHandler {
 
     MinMaxAnnotationHandler(long seed) {
-        random = new Random(seed);
+        super(seed);
     }
 
     @Override
@@ -49,7 +44,6 @@ class MinMaxAnnotationHandler implements BeanValidationAnnotationHandler {
                 .getAnnotation(field, Max.class);
         Min minAnnotation = ReflectionUtils
                 .getAnnotation(field, Min.class);
-
         Long maxValue = null;
         Long minValue = null;
 
@@ -60,49 +54,6 @@ class MinMaxAnnotationHandler implements BeanValidationAnnotationHandler {
         if (minAnnotation != null) {
             minValue = minAnnotation.value();
         }
-
-        if (fieldType.equals(Byte.TYPE) || fieldType.equals(Byte.class)) {
-            return new ByteRangeRandomizer(
-                    minValue == null ? null : minValue.byteValue(),
-                    maxValue == null ? null : maxValue.byteValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(Short.TYPE) || fieldType.equals(Short.class)) {
-            return new ShortRangeRandomizer(
-                    minValue == null ? null : minValue.shortValue(),
-                    maxValue == null ? null : maxValue.shortValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(Integer.TYPE) || fieldType.equals(Integer.class)) {
-            return new IntegerRangeRandomizer(
-                    minValue == null ? null : minValue.intValue(),
-                    maxValue == null ? null : maxValue.intValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(Long.TYPE) || fieldType.equals(Long.class)) {
-            return new LongRangeRandomizer(
-                    minValue == null ? null : minValue,
-                    maxValue == null ? null : maxValue,
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(BigInteger.class)) {
-            return new BigIntegerRangeRandomizer(
-                    minValue == null ? null : minValue.intValue(),
-                    maxValue == null ? null : maxValue.intValue(),
-                    random.nextLong()
-            );
-        }
-        if (fieldType.equals(BigDecimal.class)) {
-            return new BigDecimalRangeRandomizer(
-                    minValue == null ? null : minValue.doubleValue(),
-                    maxValue == null ? null : maxValue.doubleValue(),
-                    random.nextLong()
-            );
-        }
-        return null;
+        return getRandomizer(fieldType, new BigDecimal(String.valueOf(minValue)), new BigDecimal(String.valueOf(maxValue)));
     }
 }

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/NegativeAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/NegativeAnnotationHandler.java
@@ -24,21 +24,18 @@
 package org.jeasy.random.validation;
 
 import org.jeasy.random.api.Randomizer;
-import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
 
 import java.lang.reflect.Field;
-import java.util.Random;
+import java.math.BigDecimal;
 
-class NegativeAnnotationHandler implements BeanValidationAnnotationHandler {
-
-    private final Random random;
+class NegativeAnnotationHandler extends AbstractNumberBaseAnnotationHandler {
 
     NegativeAnnotationHandler(final long seed) {
-        random = new Random(seed);
+        super(seed);
     }
 
     @Override
     public Randomizer<?> getRandomizer(Field field) {
-        return new IntegerRangeRandomizer(Integer.MIN_VALUE, -1, random.nextLong());
+        return getRandomizer(field.getType(),  BigDecimal.ZERO, null);
     }
 }

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/NegativeOrZeroAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/NegativeOrZeroAnnotationHandler.java
@@ -24,21 +24,17 @@
 package org.jeasy.random.validation;
 
 import org.jeasy.random.api.Randomizer;
-import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
 
 import java.lang.reflect.Field;
-import java.util.Random;
+import java.math.BigDecimal;
 
-class NegativeOrZeroAnnotationHandler implements BeanValidationAnnotationHandler {
-
-    private final Random random;
-
+class NegativeOrZeroAnnotationHandler extends AbstractNumberBaseAnnotationHandler {
     NegativeOrZeroAnnotationHandler(final long seed) {
-        random = new Random(seed);
+        super(seed);
     }
 
     @Override
     public Randomizer<?> getRandomizer(Field field) {
-        return new IntegerRangeRandomizer(Integer.MIN_VALUE, 0, random.nextLong());
+        return getRandomizer(field.getType(), new BigDecimal("0.001"), null);
     }
 }

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/PositiveAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/PositiveAnnotationHandler.java
@@ -24,21 +24,18 @@
 package org.jeasy.random.validation;
 
 import org.jeasy.random.api.Randomizer;
-import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
 
 import java.lang.reflect.Field;
-import java.util.Random;
+import java.math.BigDecimal;
 
-class PositiveAnnotationHandler implements BeanValidationAnnotationHandler {
-
-    private final Random random;
+class PositiveAnnotationHandler extends AbstractNumberBaseAnnotationHandler {
 
     PositiveAnnotationHandler(final long seed) {
-        random = new Random(seed);
+        super(seed);
     }
 
     @Override
     public Randomizer<?> getRandomizer(Field field) {
-        return new IntegerRangeRandomizer(1, Integer.MAX_VALUE, random.nextLong());
+        return getRandomizer(field.getType(), null, BigDecimal.ONE);
     }
 }

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/PositiveOrZeroAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/PositiveOrZeroAnnotationHandler.java
@@ -24,21 +24,18 @@
 package org.jeasy.random.validation;
 
 import org.jeasy.random.api.Randomizer;
-import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
 
 import java.lang.reflect.Field;
-import java.util.Random;
+import java.math.BigDecimal;
 
-class PositiveOrZeroAnnotationHandler implements BeanValidationAnnotationHandler {
-
-    private final Random random;
+class PositiveOrZeroAnnotationHandler extends AbstractNumberBaseAnnotationHandler {
 
     PositiveOrZeroAnnotationHandler(final long seed) {
-        random = new Random(seed);
+        super(seed);
     }
 
     @Override
     public Randomizer<?> getRandomizer(Field field) {
-        return new IntegerRangeRandomizer(0, Integer.MAX_VALUE, random.nextLong());
+        return getRandomizer(field.getType(), null, BigDecimal.ONE);
     }
 }

--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/PositiveOrZeroAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/PositiveOrZeroAnnotationHandler.java
@@ -36,6 +36,6 @@ class PositiveOrZeroAnnotationHandler extends AbstractNumberBaseAnnotationHandle
 
     @Override
     public Randomizer<?> getRandomizer(Field field) {
-        return getRandomizer(field.getType(), null, BigDecimal.ONE);
+        return getRandomizer(field.getType(), null, BigDecimal.ZERO);
     }
 }

--- a/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationAnnotatedBean.java
+++ b/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationAnnotatedBean.java
@@ -86,6 +86,18 @@ class BeanValidationAnnotatedBean {
     @NegativeOrZero
     private int negativeOrZero;
 
+    @Positive
+    private Long positiveLong;
+
+    @PositiveOrZero
+    private Long positiveOrZeroLong;
+
+    @Negative
+    private Long negativeLong;
+
+    @NegativeOrZero
+    private Long negativeOrZeroLong;
+
     @NotBlank
     private String notBlank;
 
@@ -98,28 +110,28 @@ class BeanValidationAnnotatedBean {
     @Null
     private String unusedString;
 
-    @Size(min=2, max=10)
+    @Size(min = 2, max = 10)
     private String briefMessage;
 
-    @Size(min=2, max=10)
+    @Size(min = 2, max = 10)
     private Collection<String> sizedCollection;
 
-    @Size(min=2, max=10)
+    @Size(min = 2, max = 10)
     private List<String> sizedList;
 
-    @Size(min=2, max=10)
+    @Size(min = 2, max = 10)
     private Set<String> sizedSet;
 
-    @Size(min=2, max=10)
+    @Size(min = 2, max = 10)
     private Map<String, Integer> sizedMap;
 
-    @Size(min=2, max=10)
+    @Size(min = 2, max = 10)
     private String[] sizedArray;
 
-    @Size(min=2)
+    @Size(min = 2)
     private String sizedString;
 
-    @Pattern(regexp="[a-z]{4}")
+    @Pattern(regexp = "[a-z]{4}")
     private String regexString;
 
     public BeanValidationAnnotatedBean() {
@@ -195,6 +207,22 @@ class BeanValidationAnnotatedBean {
 
     public int getNegativeOrZero() {
         return this.negativeOrZero;
+    }
+
+    public Long getPositiveLong() {
+        return positiveLong;
+    }
+
+    public Long getPositiveOrZeroLong() {
+        return positiveOrZeroLong;
+    }
+
+    public Long getNegativeLong() {
+        return negativeLong;
+    }
+
+    public Long getNegativeOrZeroLong() {
+        return negativeOrZeroLong;
     }
 
     public String getNotBlank() {
@@ -315,6 +343,22 @@ class BeanValidationAnnotatedBean {
 
     public void setNegativeOrZero(int negativeOrZero) {
         this.negativeOrZero = negativeOrZero;
+    }
+
+    public void setPositiveLong(Long positiveLong) {
+        this.positiveLong = positiveLong;
+    }
+
+    public void setPositiveOrZeroLong(Long positiveOrZeroLong) {
+        this.positiveOrZeroLong = positiveOrZeroLong;
+    }
+
+    public void setNegativeLong(Long negativeLong) {
+        this.negativeLong = negativeLong;
+    }
+
+    public void setNegativeOrZeroLong(Long negativeOrZeroLong) {
+        this.negativeOrZeroLong = negativeOrZeroLong;
     }
 
     public void setNotBlank(String notBlank) {

--- a/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationTest.java
+++ b/easy-random-bean-validation/src/test/java/org/jeasy/random/validation/BeanValidationTest.java
@@ -23,23 +23,22 @@
  */
 package org.jeasy.random.validation;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.math.BigDecimal;
-import java.util.Date;
-import java.time.LocalDateTime;
-import java.util.Set;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import javax.validation.constraints.Digits;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Set;
 
-import org.jeasy.random.EasyRandom;
-import org.jeasy.random.EasyRandomParameters;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class BeanValidationTest {
 
@@ -83,6 +82,14 @@ class BeanValidationTest {
         assertThat(bean.getNegative()).isLessThan(0);// @Negative int negative;
 
         assertThat(bean.getNegativeOrZero()).isLessThanOrEqualTo(0);// @NegativeOrZero int negativeOrZero;
+
+        assertThat(bean.getPositiveLong()).isGreaterThan(0);// @Positive Long positive;
+
+        assertThat(bean.getPositiveOrZeroLong()).isGreaterThanOrEqualTo(0);// @PositiveOrZero Long positiveOrZero;
+
+        assertThat(bean.getNegativeLong()).isLessThan(0);// @Negative Long negative;
+
+        assertThat(bean.getNegativeOrZeroLong()).isLessThanOrEqualTo(0);// @NegativeOrZero Long negativeOrZero;
 
         assertThat(bean.getNotBlank()).isNotBlank(); // @NotBlank String notBlank;
 


### PR DESCRIPTION
Make number-based validation annotation handlers support primitive wrappers such as Long, Integer, Byte etc.
Please check #420 for the bug detail.