### PR TITLE
#425 Support type variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ If you have any question, suggestion, or feedback, do not hesitate to use the [G
 * [Nikola Milivojevic](https://github.com/dziga)
 * [nrenzoni](https://github.com/nrenzoni)
 * [Oleksandr Shcherbyna](https://github.com/sansherbina)
+* [Olli Kuonanoja](https://github.com/ollik1)
 * [Petromir Dzhunev](https://github.com/petromir)
 * [Rebecca McQuary](https://github.com/rmcquary)
 * [Rémi Alvergnat](http://www.pragmasphere.com)

--- a/easy-random-core/src/main/java/org/jeasy/random/EasyRandom.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/EasyRandom.java
@@ -25,6 +25,7 @@ package org.jeasy.random;
 
 import org.jeasy.random.api.*;
 import org.jeasy.random.randomizers.misc.EnumRandomizer;
+import org.jeasy.random.util.GenericField;
 import org.jeasy.random.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
@@ -148,7 +149,7 @@ public class EasyRandom extends Random {
             context.addPopulatedBean(type, result);
 
             // retrieve declared and inherited fields
-            List<Field> fields = getDeclaredFields(result);
+            List<GenericField> fields = getDeclaredFields(result);
             // we can not use type here, because with classpath scanning enabled the result can be a subtype
             fields.addAll(getInheritedFields(result.getClass()));
 
@@ -190,17 +191,17 @@ public class EasyRandom extends Random {
         return null;
     }
 
-    private <T> void populateFields(final List<Field> fields, final T result, final RandomizationContext context) throws IllegalAccessException {
-        for (final Field field : fields) {
+    private <T> void populateFields(final List<GenericField> fields, final T result, final RandomizationContext context) throws IllegalAccessException {
+        for (final GenericField field : fields) {
             populateField(field, result, context);
         }
     }
 
-    private <T> void populateField(final Field field, final T result, final RandomizationContext context) throws IllegalAccessException {
-        if (exclusionPolicy.shouldBeExcluded(field, context)) {
+    private <T> void populateField(final GenericField field, final T result, final RandomizationContext context) throws IllegalAccessException {
+        if (exclusionPolicy.shouldBeExcluded(field.getField(), context)) {
             return;
         }
-        if (!parameters.isOverrideDefaultInitialization() && getFieldValue(result, field) != null && !isPrimitiveFieldWithDefaultValue(result, field)) {
+        if (!parameters.isOverrideDefaultInitialization() && getFieldValue(result, field.getField()) != null && !isPrimitiveFieldWithDefaultValue(result, field.getField())) {
           return;
         }
         fieldPopulator.populateField(result, field, context);

--- a/easy-random-core/src/main/java/org/jeasy/random/util/GenericField.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/util/GenericField.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random.util;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+/**
+ * Support type variables for {@link Field}
+ *
+ * When using type variables, {@link Field#getType()} will return the lower bound class.
+ * However, in case the generic field is part of a base class, the actual type is sometimes
+ * known. This class wraps {@link Field} and contains the actual type as well.
+ *
+ */
+public class GenericField {
+    private final Field field;
+    private final Class<?> type;
+
+    public GenericField(Field field, Class<?> type) {
+        this.field = field;
+        this.type = type;
+    }
+
+    public GenericField(Field field) {
+        this(field, field.getType());
+    }
+
+    /**
+     * @return The wrapped {@link Field}
+     */
+    public Field getField() {
+        return field;
+    }
+
+    /**
+     * @return The type of the field, possibly a resolved type variable
+     */
+    public Class<?> getType() {
+        return type;
+    }
+
+    public String getName() {
+        return field.getName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GenericField that = (GenericField) o;
+        return Objects.equals(field, that.field) &&
+                Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, type);
+    }
+
+    @Override
+    public String toString() {
+        return "GenericField{" +
+                "field=" + field +
+                ", type=" + type +
+                '}';
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -271,6 +271,66 @@ class EasyRandomTest {
         assertThat(foo.names.length).isNotEqualTo(foo.addresses.length);
     }
 
+    @Test
+    void genericBaseClass() {
+        class Concrete extends GenericBaseClass<Integer> {
+            private final String y;
+
+            public Concrete(int x, String y) {
+                super(x);
+                this.y = y;
+            }
+
+            public String getY() {
+                return y;
+            }
+        }
+
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        assertThat(concrete.getX().getClass()).isEqualTo(Integer.class);
+        assertThat(concrete.getY().getClass()).isEqualTo(String.class);
+    }
+
+    @Test
+    void genericBaseClassWithBean() {
+        class Concrete extends GenericBaseClass<Street> {
+            private final String y;
+
+            public Concrete(Street x, String y) {
+                super(x);
+                this.y = y;
+            }
+
+            public String getY() {
+                return y;
+            }
+        }
+
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        assertThat(concrete.getX().getClass()).isEqualTo(Street.class);
+        assertThat(concrete.getY().getClass()).isEqualTo(String.class);
+    }
+
+    @Test
+    void boundedBaseClass() {
+        class Concrete extends BoundedBaseClass<BoundedBaseClass.IntWrapper> {
+            private final String y;
+
+            public Concrete(BoundedBaseClass.IntWrapper x, String y) {
+                super(x);
+                this.y = y;
+            }
+
+            public String getY() {
+                return y;
+            }
+        }
+
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        assertThat(concrete.getX().getClass()).isEqualTo(BoundedBaseClass.IntWrapper.class);
+        assertThat(concrete.getY().getClass()).isEqualTo(String.class);
+    }
+
     private void validatePerson(final Person person) {
         assertThat(person).isNotNull();
         assertThat(person.getEmail()).isNotEmpty();

--- a/easy-random-core/src/test/java/org/jeasy/random/FieldPopulatorTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/FieldPopulatorTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import javax.xml.bind.JAXBElement;
 
+import org.jeasy.random.util.GenericField;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -87,7 +88,7 @@ class FieldPopulatorTest {
         when(randomizerProvider.getRandomizerByField(name, context)).thenReturn(randomizer);
 
         // When
-        fieldPopulator.populateField(human, name, context);
+        fieldPopulator.populateField(human, new GenericField(name), context);
 
         // Then
         assertThat(human.getName()).isNull();
@@ -103,7 +104,7 @@ class FieldPopulatorTest {
         when(randomizer.getRandomValue()).thenReturn(NAME);
 
         // When
-        fieldPopulator.populateField(human, name, context);
+        fieldPopulator.populateField(human, new GenericField(name), context);
 
         // Then
         assertThat(human.getName()).isEqualTo(NAME);
@@ -119,7 +120,7 @@ class FieldPopulatorTest {
         when(arrayPopulator.getRandomArray(strings.getType(), context)).thenReturn(object);
 
         // When
-        fieldPopulator.populateField(arrayBean, strings, context);
+        fieldPopulator.populateField(arrayBean, new GenericField(strings), context);
 
         // Then
         assertThat(arrayBean.getStrings()).isEqualTo(object);
@@ -134,7 +135,7 @@ class FieldPopulatorTest {
         RandomizationContext context = new RandomizationContext(CollectionBean.class, new EasyRandomParameters());
 
         // When
-        fieldPopulator.populateField(collectionBean, strings, context);
+        fieldPopulator.populateField(collectionBean, new GenericField(strings), context);
 
         // Then
         assertThat(collectionBean.getTypedCollection()).isEqualTo(persons);
@@ -149,7 +150,7 @@ class FieldPopulatorTest {
         RandomizationContext context = new RandomizationContext(MapBean.class, new EasyRandomParameters());
 
         // When
-        fieldPopulator.populateField(mapBean, strings, context);
+        fieldPopulator.populateField(mapBean, new GenericField(strings), context);
 
         // Then
         assertThat(mapBean.getTypedMap()).isEqualTo(idToPerson);
@@ -164,7 +165,7 @@ class FieldPopulatorTest {
         when(context.hasExceededRandomizationDepth()).thenReturn(true);
 
         // When
-        fieldPopulator.populateField(human, name, context);
+        fieldPopulator.populateField(human, new GenericField(name), context);
 
         // Then
         assertThat(human.getName()).isNull();
@@ -179,7 +180,7 @@ class FieldPopulatorTest {
       JaxbElementFieldBean jaxbElementFieldBean = new JaxbElementFieldBean();
       RandomizationContext context = Mockito.mock(RandomizationContext.class);
 
-      thenThrownBy(() -> { fieldPopulator.populateField(jaxbElementFieldBean, jaxbElementField, context); })
+      thenThrownBy(() -> { fieldPopulator.populateField(jaxbElementFieldBean, new GenericField(jaxbElementField), context); })
           .hasMessage("Unable to create type: javax.xml.bind.JAXBElement for field: jaxbElementField of class: org.jeasy.random.FieldPopulatorTest$JaxbElementFieldBean");
     }
 

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/BoundedBaseClass.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/BoundedBaseClass.java
@@ -1,12 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2018 Nosto Solutions Ltd All Rights Reserved.
- * <p>
- * This software is the confidential and proprietary information of
- * Nosto Solutions Ltd ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the agreement you entered into with
- * Nosto Solutions Ltd.
- ******************************************************************************/
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
 package org.jeasy.random.beans;
 
 public abstract class BoundedBaseClass<T extends BoundedBaseClass.SomeInterface> {

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/BoundedBaseClass.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/BoundedBaseClass.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Nosto Solutions Ltd All Rights Reserved.
+ * <p>
+ * This software is the confidential and proprietary information of
+ * Nosto Solutions Ltd ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the agreement you entered into with
+ * Nosto Solutions Ltd.
+ ******************************************************************************/
+package org.jeasy.random.beans;
+
+public abstract class BoundedBaseClass<T extends BoundedBaseClass.SomeInterface> {
+    private final T x;
+
+    public BoundedBaseClass(T x) {
+        this.x = x;
+    }
+
+    public T getX() {
+        return x;
+    }
+
+    public interface SomeInterface { }
+
+    public static class IntWrapper implements SomeInterface {
+        private final int value;
+
+        public IntWrapper(int value) {
+            this.value = value;
+        }
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/GenericBaseClass.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/GenericBaseClass.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random.beans;
+
+public abstract class GenericBaseClass<T> {
+    private final T x;
+
+    public GenericBaseClass(T x) {
+        this.x = x;
+    }
+
+    public T getX() {
+        return x;
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/GenericBaseClass2.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/GenericBaseClass2.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random.beans;
+
+public class GenericBaseClass2<T, U> {
+    private final T x;
+    private final U y;
+
+    public GenericBaseClass2(T x, U y) {
+        this.x = x;
+        this.y = y;
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/util/ReflectionUtilsTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/util/ReflectionUtilsTest.java
@@ -64,6 +64,44 @@ class ReflectionUtilsTest {
     }
 
     @Test
+    void testGetInheritedFieldsTypeVariable() throws NoSuchFieldException {
+        class Concrete extends GenericBaseClass<Boolean> {
+            public Concrete(Boolean x) {
+                super(x);
+            }
+        }
+        assertThat(ReflectionUtils.getInheritedFields(Concrete.class))
+                .containsExactlyInAnyOrder(new GenericField(GenericBaseClass.class.getDeclaredField("x"),
+                        Boolean.class));
+    }
+
+    @Test
+    void testGetInheritedFieldsMissingTypeVariable() throws NoSuchFieldException {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        class Concrete extends GenericBaseClass {
+            public Concrete(Object x) {
+                super(x);
+            }
+        }
+        assertThat(ReflectionUtils.getInheritedFields(Concrete.class))
+                .containsExactlyInAnyOrder(new GenericField(GenericBaseClass.class.getDeclaredField("x"),
+                        Object.class));
+    }
+
+    @Test
+    void testGetInheritedFieldsMultipleTypeVariables() throws NoSuchFieldException {
+        class Concrete extends GenericBaseClass2<String, Integer> {
+
+            public Concrete(String x, Integer y) {
+                super(x, y);
+            }
+        }
+        assertThat(ReflectionUtils.getInheritedFields(Concrete.class))
+                .containsExactlyInAnyOrder(new GenericField(GenericBaseClass2.class.getDeclaredField("x"), String.class),
+                        new GenericField(GenericBaseClass2.class.getDeclaredField("y"), Integer.class));
+    }
+
+    @Test
     void testIsStatic() throws Exception {
         assertThat(ReflectionUtils.isStatic(Human.class.getField("SERIAL_VERSION_UID"))).isTrue();
     }


### PR DESCRIPTION
See https://github.com/j-easy/easy-random/issues/425

Pass the actual type along with a field that will be used to pick
correct randomizer. Consider the following example:
```
abstract class Base<T> {
	T t;
}
class Concrete extends Base<String> {}
```
If we only rely on `Field.getType()`, property `Concrete.t` would be
randomized as `Object` and then cause a runtime exception when used.

Java reflection API provides a way to get the actual type, in this case
`String`. This information is passed in `GenericField` so that the
correct randomizer can be picked later.
