### PR TITLE
Pass properly updated context to a ContextAwareRandomizer

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/FieldPopulator.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/FieldPopulator.java
@@ -73,10 +73,10 @@ class FieldPopulator {
         if (randomizer instanceof SkipRandomizer) {
             return;
         }
+        context.pushStackItem(new RandomizationContextStackItem(target, field));
         if (randomizer instanceof ContextAwareRandomizer) {
             ((ContextAwareRandomizer<?>) randomizer).setRandomizerContext(context);
         }
-        context.pushStackItem(new RandomizationContextStackItem(target, field));
         if(!context.hasExceededRandomizationDepth()) {
             Object value;
             if (randomizer != null) {

--- a/easy-random-core/src/test/java/org/jeasy/random/FieldPopulatorTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/FieldPopulatorTest.java
@@ -25,6 +25,7 @@ package org.jeasy.random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
@@ -35,6 +36,7 @@ import java.util.Map;
 
 import javax.xml.bind.JAXBElement;
 
+import org.jeasy.random.api.ContextAwareRandomizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -63,6 +65,8 @@ class FieldPopulatorTest {
     private RegistriesRandomizerProvider randomizerProvider;
     @Mock
     private Randomizer randomizer;
+    @Mock
+    private ContextAwareRandomizer contextAwareRandomizer;
     @Mock
     private ArrayPopulator arrayPopulator;
     @Mock
@@ -107,6 +111,27 @@ class FieldPopulatorTest {
 
         // Then
         assertThat(human.getName()).isEqualTo(NAME);
+    }
+
+    @Test
+    void whenContextAwareRandomizerIsRegisteredForTheField_thenTheFieldShouldBeOnTopOfTheSuppliedContextStack() throws Exception {
+        // Given
+        Field name = Human.class.getDeclaredField("name");
+        Human human = new Human();
+        RandomizationContext context = new RandomizationContext(Human.class, new EasyRandomParameters());
+        final Human[] currentObjectFromContext = new Human[1];
+        when(randomizerProvider.getRandomizerByField(name, context)).thenReturn(contextAwareRandomizer);
+        when(contextAwareRandomizer.getRandomValue()).thenReturn(NAME);
+        doAnswer(invocationOnMock -> {
+            currentObjectFromContext[0] = (Human)invocationOnMock.getArgument(0, RandomizationContext.class).getCurrentObject();
+            return null;
+        }).when(contextAwareRandomizer).setRandomizerContext(context);
+
+        // When
+        fieldPopulator.populateField(human, name, context);
+
+        // Then
+        assertThat(currentObjectFromContext[0]).isEqualTo(human);
     }
 
     @Test

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/CityRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/CityRandomizer.java
@@ -63,7 +63,9 @@ public class CityRandomizer extends FakerBasedRandomizer<String> {
      * Create a new {@link CityRandomizer}.
      *
      * @return a new {@link CityRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static CityRandomizer aNewCityRandomizer() {
         return new CityRandomizer();
     }
@@ -73,7 +75,9 @@ public class CityRandomizer extends FakerBasedRandomizer<String> {
      *
      * @param seed the initial seed
      * @return a new {@link CityRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static CityRandomizer aNewCityRandomizer(final long seed) {
         return new CityRandomizer(seed);
     }
@@ -84,7 +88,9 @@ public class CityRandomizer extends FakerBasedRandomizer<String> {
      * @param seed   the initial seed
      * @param locale the locale to use
      * @return a new {@link CityRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static CityRandomizer aNewCityRandomizer(final long seed, final Locale locale) {
         return new CityRandomizer(seed, locale);
     }

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/IsbnRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/IsbnRandomizer.java
@@ -63,7 +63,9 @@ public class IsbnRandomizer extends FakerBasedRandomizer<String> {
      * Create a new {@link IsbnRandomizer}.
      *
      * @return a new {@link IsbnRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static IsbnRandomizer aNewIsbnRandomizer() {
         return new IsbnRandomizer();
     }
@@ -73,7 +75,9 @@ public class IsbnRandomizer extends FakerBasedRandomizer<String> {
      *
      * @param seed the initial seed
      * @return a new {@link IsbnRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static IsbnRandomizer aNewIsbnRandomizer(final long seed) {
         return new IsbnRandomizer(seed);
     }
@@ -84,7 +88,9 @@ public class IsbnRandomizer extends FakerBasedRandomizer<String> {
      * @param seed   the initial seed
      * @param locale the locale to use
      * @return a new {@link IsbnRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static IsbnRandomizer aNewIsbnRandomizer(final long seed, final Locale locale) {
         return new IsbnRandomizer(seed, locale);
     }

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/LastNameRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/LastNameRandomizer.java
@@ -63,7 +63,9 @@ public class LastNameRandomizer extends FakerBasedRandomizer<String> {
      * Create a new {@link LastNameRandomizer}.
      *
      * @return a new {@link LastNameRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static LastNameRandomizer aNewLastNameRandomizer() {
         return new LastNameRandomizer();
     }
@@ -73,7 +75,9 @@ public class LastNameRandomizer extends FakerBasedRandomizer<String> {
      *
      * @param seed the initial seed
      * @return a new {@link LastNameRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static LastNameRandomizer aNewLastNameRandomizer(final long seed) {
         return new LastNameRandomizer(seed);
     }
@@ -84,7 +88,9 @@ public class LastNameRandomizer extends FakerBasedRandomizer<String> {
      * @param seed   the initial seed
      * @param locale the locale to use
      * @return a new {@link LastNameRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static LastNameRandomizer aNewLastNameRandomizer(final long seed, final Locale locale) {
         return new LastNameRandomizer(seed, locale);
     }

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/MacAddressRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/MacAddressRandomizer.java
@@ -77,7 +77,9 @@ public class MacAddressRandomizer extends FakerBasedRandomizer<String> {
      * @param seed
      *          the initial seed
      * @return a new {@link MacAddressRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static MacAddressRandomizer aNewMacAddressRandomizer(final long seed) {
         return new MacAddressRandomizer(seed);
     }
@@ -90,7 +92,9 @@ public class MacAddressRandomizer extends FakerBasedRandomizer<String> {
      * @param locale
      *          the locale to use
      * @return a new {@link MacAddressRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static MacAddressRandomizer aNewMacAddressRandomizer(final long seed, final Locale locale) {
         return new MacAddressRandomizer(seed, locale);
     }

--- a/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/WordRandomizer.java
+++ b/easy-random-randomizers/src/main/java/org/jeasy/random/randomizers/WordRandomizer.java
@@ -63,7 +63,9 @@ public class WordRandomizer extends FakerBasedRandomizer<String> {
      * Create a new {@link WordRandomizer}.
      *
      * @return a new {@link WordRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static WordRandomizer aNewWordRandomizer() {
         return new WordRandomizer();
     }
@@ -73,7 +75,9 @@ public class WordRandomizer extends FakerBasedRandomizer<String> {
      *
      * @param seed the initial seed
      * @return a new {@link WordRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static WordRandomizer aNewWordRandomizer(final long seed) {
         return new WordRandomizer(seed);
     }
@@ -84,7 +88,9 @@ public class WordRandomizer extends FakerBasedRandomizer<String> {
      * @param seed   the initial seed
      * @param locale the locale to use
      * @return a new {@link WordRandomizer}
+     * @deprecated in favor of the equivalent constructor
      */
+    @Deprecated
     public static WordRandomizer aNewWordRandomizer(final long seed, final Locale locale) {
         return new WordRandomizer(seed, locale);
     }


### PR DESCRIPTION
The stack of the context passed to any `ContextAwareRandomizer` via `setRandomizerContext()` does not have the actual currently processed field on top, but the enclosing/parent field instead. 
This makes it impossible in a randomizer to acquire and use the current field metadata to generate a random value (e.g. based on attributes of a custom annotation on it).
