### PR TITLE
Make ObjenesisObjectFactory public

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/ObjenesisObjectFactory.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/ObjenesisObjectFactory.java
@@ -40,7 +40,7 @@ import static org.jeasy.random.util.ReflectionUtils.isAbstract;
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
 @SuppressWarnings({"unchecked"})
-class ObjenesisObjectFactory implements ObjectFactory {
+public class ObjenesisObjectFactory implements ObjectFactory {
 
     private final Objenesis objenesis = new ObjenesisStd();
 


### PR DESCRIPTION
Hi @benas, this PR corresponds with the discussion from https://github.com/j-easy/easy-random/pull/412. Indeed, I overlooked the possibility of solving the issue using `ObjectFactory` which is quite simple. However, I find it very useful to preserve the default behaviour for not nested objects while the current design discourages that. This PR changes `ObjenesisObjectFactory` to the public to make the preservation straightforward.

I was thinking about solving the 2nd scenario from https://github.com/j-easy/easy-random/issues/405 (which I was trying to address there https://github.com/j-easy/easy-random/pull/412, but you rejected it due to increased complexity). The 2nd scenario is much more challenging to be solved using the `ObjectFactory` as it does not have access to `Stack<RandomizationContextStackItem> stack` which could be very handy in detecting cycles. What do you think about making the stack available in `ObjectFactory`? If that did not break other design principles, I'd create a PR with such a change.