### PR TITLE
Fix #437: chain setters and overriden fields issue

### DIFF
--- a/easy-random-core/pom.xml
+++ b/easy-random-core/pom.xml
@@ -58,10 +58,6 @@
             <artifactId>classgraph</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/easy-random-core/src/main/java/org/jeasy/random/util/ReflectionUtils.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/util/ReflectionUtils.java
@@ -132,9 +132,9 @@ public final class ReflectionUtils {
      */
     public static void setProperty(final Object object, final Field field, final Object value) throws IllegalAccessException, InvocationTargetException {
         try {
-            Method setter = getSetter(object.getClass(), field.getName(), field.getType());
-            if (setter != null) {
-                setter.invoke(object, value);
+            Optional<Method> setter = getWriteMethod(field);
+            if (setter.isPresent()) {
+                setter.get().invoke(object, value);
             } else {
                 setFieldValue(object, field, value);
             }
@@ -538,6 +538,16 @@ public final class ReflectionUtils {
     }
 
     /**
+     * Get the write method for given field.
+     *
+     * @param field field to get the write method for
+     * @return Optional of write method or empty if field has no write method
+     */
+    private static Optional<Method> getWriteMethod(Field field) {
+        return getPublicMethod("set" + capitalize(field.getName()), field.getDeclaringClass(), field.getType());
+    }
+
+    /**
      * Get the read method for given field.
      * @param field field to get the read method for.
      * @return Optional of read method or empty if field has no read method
@@ -545,7 +555,7 @@ public final class ReflectionUtils {
     public static Optional<Method> getReadMethod(Field field) {
         String fieldName = field.getName();
         Class<?> fieldClass = field.getDeclaringClass();
-        String capitalizedFieldName = fieldName.substring(0, 1).toUpperCase(ENGLISH) + fieldName.substring(1);
+        String capitalizedFieldName = capitalize(fieldName);
         // try to find getProperty
         Optional<Method> getter = getPublicMethod("get" + capitalizedFieldName, fieldClass);
         if (getter.isPresent()) {
@@ -555,9 +565,13 @@ public final class ReflectionUtils {
         return getPublicMethod("is" + capitalizedFieldName, fieldClass);
     }
 
-    private static Optional<Method> getPublicMethod(String name, Class<?> target) {
+    private static String capitalize(String propertyName) {
+        return propertyName.substring(0, 1).toUpperCase(ENGLISH) + propertyName.substring(1);
+    }
+
+    private static Optional<Method> getPublicMethod(String name, Class<?> target, Class<?>... parameterTypes) {
         try {
-            return Optional.of(target.getMethod(name));
+            return Optional.of(target.getMethod(name, parameterTypes));
         } catch (NoSuchMethodException | SecurityException e) {
             return Optional.empty();
         }
@@ -593,27 +607,6 @@ public final class ReflectionUtils {
             return (Randomizer<T>) type.newInstance();
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException e) {
             throw new ObjectCreationException(format("Could not create Randomizer of type: %s with constructor arguments: %s", type, Arrays.toString(randomizerArguments)), e);
-        }
-    }
-
-    private static Method getSetter(Class<?> beanType, String propertyName, Class<?> propertyType) {
-        String setterName = "set" + propertyName.substring(0, 1).toUpperCase(ENGLISH) + propertyName.substring(1);
-        // implementation note: we go from subclass to super-class order - hence getDeclaredMethods
-        for (Method method : beanType.getDeclaredMethods()) {
-            // note: the return type void requirement is relaxed (allow chained setters)
-            if (setterName.equals(method.getName())
-                    && Modifier.isPublic(method.getModifiers())
-                    && !method.isBridge()
-                    && method.getParameterCount() == 1
-                    && method.getParameterTypes()[0] == propertyType) {
-                return method;
-            }
-        }
-        Class<?> superClass = beanType.getSuperclass();
-        if (superClass == null || superClass == Object.class) {
-            return null;
-        } else {
-            return getSetter(superClass, propertyName, propertyType);
         }
     }
 

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomChainedSettersTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomChainedSettersTest.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class EasyRandomChainedSettersTest {
+
+    @Test
+    void chainSettersShouldBeRandomized() {
+        EasyRandom easyRandom = new EasyRandom(new EasyRandomParameters());
+
+        SubClassA value = easyRandom.nextObject(SubClassA.class);
+
+        assertNotNull(value.getField());
+        assertTrue(value.getF() != 0);
+    }
+
+    public static class BaseClass {
+
+        // setter overriden
+        private String field;
+        // single-char name
+        private int f;
+
+        public BaseClass setField(String field) {
+            this.field = field;
+            return this;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public int getF() {
+            return f;
+        }
+
+        public BaseClass setF(int f) {
+            this.f = f;
+            return this;
+        }
+    }
+
+    public static class SubClassA extends BaseClass {
+
+        private SubClassB subClassB;
+    }
+
+    public static class SubClassB extends BaseClass {
+
+        @Override
+        public SubClassB setField(String field) {
+            super.setField(field);
+            return this;
+        }
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomOverridenFieldTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomOverridenFieldTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class EasyRandomOverridenFieldTest {
+
+    @Test
+    void chainSettersShouldBeRandomized() {
+        EasyRandom easyRandom = new EasyRandom(new EasyRandomParameters());
+
+        SubClass value = easyRandom.nextObject(SubClass.class);
+
+        assertFalse(((BaseClass) value).field.isEmpty());
+        assertTrue(value.field != 0);
+    }
+
+    public static class BaseClass {
+
+        // field overriden (note: not setter)
+        private String field;
+
+        public BaseClass setField(String field) {
+            this.field = field;
+            return this;
+        }
+    }
+
+    public static class SubClass extends BaseClass {
+
+        // note: field overriden
+        private int field;
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -69,10 +69,10 @@ class EasyRandomTest {
     @Test
     void generatedBeanWithFluentSetterShouldBeCorrectlyPopulated() {
         // when
-        FluentSetterBean fluentSetterBean = easyRandom.nextObject(FluentSetterBean.class);
+        ChainedSetterBean chainedSetterBean = easyRandom.nextObject(ChainedSetterBean.class);
 
         // then
-        assertThat(fluentSetterBean.getName()).isNotEmpty();
+        assertThat(chainedSetterBean.getName()).isNotEmpty();
     }
 
     @Test

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/ChainedSetterBean.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/ChainedSetterBean.java
@@ -23,16 +23,27 @@
  */
 package org.jeasy.random.beans;
 
-public class FluentSetterBean {
+public class ChainedSetterBean {
 
-    public String name;
+    private String name;
+    private int index;
 
-    public FluentSetterBean setName(String name) {
+    public ChainedSetterBean setName(String name) {
         this.name = name;
+        return this;
+    }
+
+    public ChainedSetterBean setIndex(int index) {
+        this.index = index;
         return this;
     }
 
     public String getName() {
         return name;
     }
+
+    public int getIndex() {
+        return index;
+    }
+
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/util/ReflectionUtilsTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/util/ReflectionUtilsTest.java
@@ -25,13 +25,11 @@ package org.jeasy.random.util;
 
 import org.jeasy.random.beans.*;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.*;
@@ -43,6 +41,8 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 class ReflectionUtilsTest {
 
@@ -226,17 +226,31 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void setPropertyFluentBean() throws NoSuchFieldException, InvocationTargetException, IllegalAccessException {
+    void setPropertyFluentBean() throws Exception {
         // given
-        FluentSetterBean fluentSetterBean = Mockito.spy(FluentSetterBean.class);
-        Field nameField = FluentSetterBean.class.getField("name");
+        ChainedSetterBean chainedSetterBean = spy(ChainedSetterBean.class);
+        Field nameField = ChainedSetterBean.class.getDeclaredField("name");
 
         // when
-        ReflectionUtils.setProperty(fluentSetterBean,nameField,"myName");
+        ReflectionUtils.setProperty(chainedSetterBean, nameField, "myName");
 
         // then
-        Mockito.verify(fluentSetterBean).setName("myName");
-        assertThat(fluentSetterBean.getName()).isEqualTo("myName");
+        verify(chainedSetterBean).setName("myName");
+        assertThat(chainedSetterBean.getName()).isEqualTo("myName");
+    }
+
+    @Test
+    void setPropertyFluentBeanPrimitiveType() throws Exception {
+        // given
+        ChainedSetterBean chainedSetterBean = spy(ChainedSetterBean.class);
+        Field indexField = ChainedSetterBean.class.getDeclaredField("index");
+
+        // when
+        ReflectionUtils.setProperty(chainedSetterBean, indexField, 100);
+
+        // then
+        verify(chainedSetterBean).setIndex(100);
+        assertThat(chainedSetterBean.getIndex()).isEqualTo(100);
     }
 
     @SuppressWarnings("unused")

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <java.version>1.8</java.version>
         <junit.version>5.6.0</junit.version>
         <faker.version>1.0.2</faker.version>
-        <commons-beanutils-version>1.9.4</commons-beanutils-version>
         <assertj.version>3.15.0</assertj.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <objenesis.version>3.1</objenesis.version>
@@ -128,11 +127,6 @@
                 <groupId>com.github.javafaker</groupId>
                 <artifactId>javafaker</artifactId>
                 <version>${faker.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>${commons-beanutils-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
There are two regression defects described in #437. The first: if there are two subclasses of a base class, the corrupted `PropertyDescriptor` information may be cached and reused. The second: if the base class has a field with chained accessors and a subclass overrides this field (not a setter, but a field), the randomization of an instance fails. Both cases are covered with tests:
- `EasyRandomChainedSettersTest`
- `EasyRandomOverridenFieldTest`

Note: both tests are success on version `4.2.0`, but will fail if you revert all other changes in `src/main/java` and `pom.xml`, hence it is a regression.

Also this PR removes `commons-beanutils` dependency as it is not required anymore. Please note, that there is a critical issue https://issues.apache.org/jira/browse/BEANUTILS-541 that caused one of described problems.