### PR TITLE
Add support for generic type variables

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/FieldPopulator.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/FieldPopulator.java
@@ -173,11 +173,19 @@ class FieldPopulator {
                 actualTypeArgument = actualTypeArguments[i];
             }
         }
+        if (actualTypeArgument == null) {
+            return field.getClass();
+        }
         Class<?> aClass;
+        String typeName = null;
         try {
-            aClass = Class.forName(actualTypeArgument.getTypeName());
+            typeName = actualTypeArgument.getTypeName();
+            aClass = Class.forName(typeName);
         } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);// the class should have been already loaded without any problem at this point
+            String message = String.format("Unable to load class %s of generic field %s in class %s. " +
+                            "Please refer to the documentation as this generic type may not be supported for randomization.",
+                    typeName, field.getName(), field.getDeclaringClass().getName());
+            throw new ObjectCreationException(message, e);
         }
         return aClass;
     }

--- a/easy-random-core/src/main/java/org/jeasy/random/FieldPopulator.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/FieldPopulator.java
@@ -165,8 +165,9 @@ class FieldPopulator {
     private Class<?> getParametrizedType(Field field, RandomizationContext context) {
         Class<?> declaringClass = field.getDeclaringClass();
         TypeVariable<? extends Class<?>>[] typeParameters = declaringClass.getTypeParameters();
-        ParameterizedType genericSuperclass = (ParameterizedType) context.getTargetType().getGenericSuperclass();
-        Type[] actualTypeArguments = genericSuperclass.getActualTypeArguments();
+        Type genericSuperclass = getGenericSuperClass(context);
+        ParameterizedType parameterizedGenericSuperType = (ParameterizedType) genericSuperclass;
+        Type[] actualTypeArguments = parameterizedGenericSuperType.getActualTypeArguments();
         Type actualTypeArgument = null;
         for (int i = 0; i < typeParameters.length; i++) {
             if (field.getGenericType().equals(typeParameters[i])) {
@@ -188,5 +189,18 @@ class FieldPopulator {
             throw new ObjectCreationException(message, e);
         }
         return aClass;
+    }
+
+    // find the generic base class in the hierarchy (which might not be the first super type)
+    private Type getGenericSuperClass(RandomizationContext context) {
+        Class<?> targetType = context.getTargetType();
+        Type genericSuperclass = targetType.getGenericSuperclass();
+        while (targetType != null && !(genericSuperclass instanceof ParameterizedType)) {
+            targetType = targetType.getSuperclass();
+            if (targetType != null) {
+                genericSuperclass = targetType.getGenericSuperclass();
+            }
+        }
+        return genericSuperclass;
     }
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -416,6 +416,22 @@ class EasyRandomTest {
         assertThat(concrete.getY()).isInstanceOf(Long.class);
     }
 
+    @Test
+    void testComplexGenericTypeRandomization() { // not supported
+        // given
+        class Base<T> {
+            T t;
+        }
+        class Concrete extends Base<List<String>> {}
+
+        assertThatThrownBy(
+                // when
+                () -> easyRandom.nextObject(Concrete.class))
+                // then
+                .isInstanceOf(ObjectCreationException.class)
+                .hasMessage("Unable to create a random instance of type class org.jeasy.random.EasyRandomTest$7Concrete");
+    }
+
     private void validatePerson(final Person person) {
         assertThat(person).isNotNull();
         assertThat(person.getEmail()).isNotEmpty();

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -271,6 +271,151 @@ class EasyRandomTest {
         assertThat(foo.names.length).isNotEqualTo(foo.addresses.length);
     }
 
+    @Test
+    void testGenericTypeRandomization() {
+        // given
+        class Base<T> {
+            T t;
+        }
+        class Concrete extends Base<String> {}
+        
+        // when
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        
+        // then
+        assertThat(concrete.t).isInstanceOf(String.class);
+        assertThat(concrete.t).isNotEmpty();
+    }
+
+    @Test
+    void testMultipleGenericTypeRandomization() {
+        // given
+        class Base<T, S> {
+            T t;
+            S s;
+        }
+        class Concrete extends Base<String, Long> {}
+        
+        // when
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        
+        // then
+        assertThat(concrete.t).isInstanceOf(String.class);
+        assertThat(concrete.s).isInstanceOf(Long.class);
+        assertThat(concrete.t).isNotEmpty();
+        assertThat(concrete.s).isNotNull();
+    }
+
+    @Test
+    void genericBaseClass() {
+        // given
+        class Concrete extends GenericBaseClass<Integer> {
+            private final String y;
+
+            public Concrete(int x, String y) {
+                super(x);
+                this.y = y;
+            }
+
+            public String getY() {
+                return y;
+            }
+        }
+
+        // when
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        
+        // then
+        assertThat(concrete.getX().getClass()).isEqualTo(Integer.class);
+        assertThat(concrete.getY().getClass()).isEqualTo(String.class);
+    }
+
+    @Test
+    void genericBaseClassWithBean() {
+        // given
+        class Concrete extends GenericBaseClass<Street> {
+            private final String y;
+
+            public Concrete(Street x, String y) {
+                super(x);
+                this.y = y;
+            }
+
+            public String getY() {
+                return y;
+            }
+        }
+
+        // when
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        
+        // then
+        assertThat(concrete.getX().getClass()).isEqualTo(Street.class);
+        assertThat(concrete.getY().getClass()).isEqualTo(String.class);
+    }
+
+    @Test
+    void boundedBaseClass() {
+        // given
+        class Concrete extends BoundedBaseClass<BoundedBaseClass.IntWrapper> {
+            private final String y;
+
+            public Concrete(BoundedBaseClass.IntWrapper x, String y) {
+                super(x);
+                this.y = y;
+            }
+
+            public String getY() {
+                return y;
+            }
+        }
+
+        // when
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        
+        // then
+        assertThat(concrete.getX().getClass()).isEqualTo(BoundedBaseClass.IntWrapper.class);
+        assertThat(concrete.getY().getClass()).isEqualTo(String.class);
+    }
+
+    @Test
+    void testMultipleGenericLevels() {
+        // given
+        abstract class BaseClass<T> {
+            protected T x;
+            BaseClass(T x) {
+                this.x = x;
+            }
+            public T getX() {
+                return x;
+            }
+        }
+
+        abstract class GenericBaseClass<T, P> extends BaseClass<T> {
+            protected P y;
+            GenericBaseClass(T x, P y) {
+                super(x);
+                this.y = y;
+            }
+            public P getY() {
+                return y;
+            }
+        }
+
+        class Concrete extends GenericBaseClass<String, Long> {
+            Concrete(String x, Long y) {
+                super(x, y);
+            }
+        }
+
+        // when
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+        
+        // then
+        assertThat(concrete.getX()).isInstanceOf(String.class);
+        assertThat(concrete.getY()).isInstanceOf(Long.class);
+    }
+
     private void validatePerson(final Person person) {
         assertThat(person).isNotNull();
         assertThat(person.getEmail()).isNotEmpty();

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -432,6 +432,36 @@ class EasyRandomTest {
                 .hasMessage("Unable to create a random instance of type class org.jeasy.random.EasyRandomTest$7Concrete");
     }
 
+    @Test
+    void testRootGenericType() { // intermediate type in the hierarchy is not generic
+        // given
+        abstract class BaseClass<T> {
+            protected T x;
+            BaseClass(T x) {
+                this.x = x;
+            }
+            public T getX() {
+                return x;
+            }
+        }
+        abstract class GenericBaseClass extends BaseClass<String> {
+            GenericBaseClass(String x) {
+                super(x);
+            }
+        }
+        class Concrete extends GenericBaseClass {
+            Concrete(String x) {
+                super(x);
+            }
+        }
+
+        // when
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+
+        // then
+        assertThat(concrete.getX()).isInstanceOf(String.class);
+    }
+
     private void validatePerson(final Person person) {
         assertThat(person).isNotNull();
         assertThat(person.getEmail()).isNotEmpty();

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/BoundedBaseClass.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/BoundedBaseClass.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random.beans;
+
+public abstract class BoundedBaseClass<T extends BoundedBaseClass.SomeInterface> {
+    private final T x;
+
+    public BoundedBaseClass(T x) {
+        this.x = x;
+    }
+
+    public T getX() {
+        return x;
+    }
+
+    public interface SomeInterface { }
+
+    public static class IntWrapper implements SomeInterface {
+        private final int value;
+
+        public IntWrapper(int value) {
+            this.value = value;
+        }
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/GenericBaseClass.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/GenericBaseClass.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random.beans;
+
+public abstract class GenericBaseClass<T> {
+    private final T x;
+
+    public GenericBaseClass(T x) {
+        this.x = x;
+    }
+
+    public T getX() {
+        return x;
+    }
+}

--- a/easy-random-core/src/test/java/org/jeasy/random/beans/GenericBaseClass2.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/beans/GenericBaseClass2.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random.beans;
+
+public class GenericBaseClass2<T, U> {
+    private final T x;
+    private final U y;
+
+    public GenericBaseClass2(T x, U y) {
+        this.x = x;
+        this.y = y;
+    }
+}


### PR DESCRIPTION
This PR is for issue #425.

It covers basic use cases of randomizing generic fields where the type is defined at the class level (or one of its base types), like:

```java
@Test
void testGenericTypeRandomization() {
    // given
    class Base<T> {
        T t;
    }
    class Concrete extends Base<String> {}
    
    // when
    Concrete concrete = easyRandom.nextObject(Concrete.class);
    
    // then
    assertThat(concrete.t).isInstanceOf(String.class);
    assertThat(concrete.t).isNotEmpty();
}
```

It also supports multiple generic types and multiple generic levels in the hierarchy (see tests). However, it does not covers complex types such as `class Concrete extends Base<List<String>> {}` in the previous example. This will be documented accordingly.

As discussed in #426 , this is a good start and may cover most use cases. Custom randomizers can be used for specific cases. Any feedback is welcome.


