### PR TITLE
Add regression test for generic fields

### DIFF
--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -484,6 +484,23 @@ class EasyRandomTest {
         assertThat(street.getType()).isNotNull();
     }
 
+    @Test
+    void testGenericFieldRandomization() {
+        // given
+        class Base<T> {
+            T t;
+        }
+        class Concrete {
+            Base<String> f;
+        }
+
+        // when
+        Concrete concrete = easyRandom.nextObject(Concrete.class);
+
+        // then
+        assertThat(concrete.f).isInstanceOf(Base.class);
+    }
+
     @Disabled("Dummy test to see possible reasons of randomization failures")
     @Test
     void tryToRandomizeAllPublicConcreteTypesInTheClasspath(){


### PR DESCRIPTION
This adds a test to spot a regression in release 5.0.0

The wrong context is used to resolve the generic parameters. Had no success yet to also find a fix.
