### PR TITLE
#472 Allow using EnumRandomizer with excluded values deterministically

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/randomizers/misc/EnumRandomizer.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/randomizers/misc/EnumRandomizer.java
@@ -76,6 +76,21 @@ public class EnumRandomizer<E extends Enum<E>> extends AbstractRandomizer<E> {
     }
 
     /**
+     * Create a new {@link EnumRandomizer}.
+     *
+     * @param enumeration    the enumeration from which this randomizer will generate random values
+     * @param seed           the initial seed
+     * @param excludedValues the values to exclude from random picking
+     * @throws IllegalArgumentException when excludedValues contains all enumeration values,
+     *                                  ie all elements from the enumeration are excluded
+     */
+    public EnumRandomizer(final Class<E> enumeration, final long seed, final E... excludedValues) throws IllegalArgumentException {
+        super(seed);
+        checkExcludedValues(enumeration, excludedValues);
+        this.enumConstants = getFilteredList(enumeration, excludedValues);
+    }
+
+    /**
      * Get a random value within an enumeration or an enumeration subset (when values are excluded)
      *
      * @return a random value within the enumeration

--- a/easy-random-core/src/test/java/org/jeasy/random/randomizers/misc/EnumRandomizerTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/randomizers/misc/EnumRandomizerTest.java
@@ -43,6 +43,13 @@ class EnumRandomizerTest extends AbstractRandomizerTest<EnumRandomizerTest.Gende
         assertThat(new EnumRandomizer(Gender.class, SEED).getRandomValue()).isEqualTo(FEMALE);
     }
 
+    @Test
+    void shouldAlwaysGenerateTheSameValueForTheSameSeedWithExcludedValues() {
+        assertThat(
+            new EnumRandomizer<>(TriState.class, SEED, TriState.Maybe).getRandomValue()).isEqualTo(
+            TriState.False);
+    }
+
     public enum Gender {
         MALE, FEMALE
     }
@@ -66,5 +73,12 @@ class EnumRandomizerTest extends AbstractRandomizerTest<EnumRandomizerTest.Gende
     public void should_return_null_for_empty_enum() {
         Empty randomElement = new EnumRandomizer<>(Empty.class).getRandomValue();
         assertThat(randomElement).isNull();
+    }
+
+    // always keep three options here, as we want to exclude one and still select the same one
+    // deterministically
+    @SuppressWarnings("unused")
+    private enum TriState {
+        True, False, Maybe
     }
 }


### PR DESCRIPTION
This PR allows using `EnumRandomizer` with excluded values in a deterministic fashion, by also passing in a seed. This was previously only possible when using all the values from the given `enum`.

closes #472 
