### PR TITLE
Expose actual randomizer provider in RandomizerContext

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/EasyRandom.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/EasyRandom.java
@@ -101,7 +101,7 @@ public class EasyRandom extends Random {
         if (type.isRecord()) {
             return createRandomRecord(type);
         } else {
-            return doPopulateBean(type, new RandomizationContext(type, parameters));
+            return doPopulateBean(type, new RandomizationContext(type, parameters, randomizerProvider));
         }
     }
 

--- a/easy-random-core/src/main/java/org/jeasy/random/RandomizationContext.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/RandomizationContext.java
@@ -24,6 +24,7 @@
 package org.jeasy.random;
 
 import org.jeasy.random.api.RandomizerContext;
+import org.jeasy.random.api.RandomizerProvider;
 
 import java.lang.reflect.Field;
 import java.util.*;
@@ -38,6 +39,8 @@ import static java.util.stream.Collectors.toList;
  */
 class RandomizationContext implements RandomizerContext {
 
+    private final RandomizerProvider randomizerProvider;
+
     private final EasyRandomParameters parameters;
 
     private final Map<Class<?>, List<Object>> populatedBeans;
@@ -50,12 +53,13 @@ class RandomizationContext implements RandomizerContext {
 
     private Object rootObject;
 
-    RandomizationContext(final Class<?> type, final EasyRandomParameters parameters) {
+    RandomizationContext(final Class<?> type, final EasyRandomParameters parameters, RandomizerProvider randomizerProvider) {
         this.type = type;
         populatedBeans = new IdentityHashMap<>();
         stack = new Stack<>();
         this.parameters = parameters;
         this.random = new Random(parameters.getSeed());
+        this.randomizerProvider = randomizerProvider;
     }
 
     void addPopulatedBean(final Class<?> type, Object object) {
@@ -146,5 +150,10 @@ class RandomizationContext implements RandomizerContext {
     @Override
     public EasyRandomParameters getParameters() {
         return parameters;
+    }
+
+    @Override
+    public RandomizerProvider getRandomizerProvider() {
+        return randomizerProvider;
     }
 }

--- a/easy-random-core/src/main/java/org/jeasy/random/api/RandomizerContext.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/api/RandomizerContext.java
@@ -70,4 +70,10 @@ public interface RandomizerContext {
      */
     EasyRandomParameters getParameters();
 
+    /**
+     * Return the currently used {@link RandomizerProvider} by the enclosing {@link EasyRandom}.
+     * @return currently build and used randomizer provider
+     */
+    RandomizerProvider getRandomizerProvider();
+
 }

--- a/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/EasyRandomTest.java
@@ -238,7 +238,7 @@ class EasyRandomTest {
             assertThat(testBean.getException()).isNotNull();
             assertThat(testBean.getClazz()).isNull();
         } catch (Exception e) {
-            fail("Should skip fields of type Class");
+            fail("Should skip fields of type Class", e);
         }
     }
 

--- a/easy-random-core/src/test/java/org/jeasy/random/FieldPopulatorTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/FieldPopulatorTest.java
@@ -85,7 +85,7 @@ class FieldPopulatorTest {
         Field name = Human.class.getDeclaredField("name");
         Human human = new Human();
         randomizer = new SkipRandomizer();
-        RandomizationContext context = new RandomizationContext(Human.class, new EasyRandomParameters());
+        RandomizationContext context = new RandomizationContext(Human.class, new EasyRandomParameters(), null);
         when(randomizerProvider.getRandomizerByField(name, context)).thenReturn(randomizer);
 
         // When
@@ -100,7 +100,7 @@ class FieldPopulatorTest {
         // Given
         Field name = Human.class.getDeclaredField("name");
         Human human = new Human();
-        RandomizationContext context = new RandomizationContext(Human.class, new EasyRandomParameters());
+        RandomizationContext context = new RandomizationContext(Human.class, new EasyRandomParameters(), null);
         when(randomizerProvider.getRandomizerByField(name, context)).thenReturn(randomizer);
         when(randomizer.getRandomValue()).thenReturn(NAME);
 
@@ -116,7 +116,7 @@ class FieldPopulatorTest {
         // Given
         Field name = Human.class.getDeclaredField("name");
         Human human = new Human();
-        RandomizationContext context = new RandomizationContext(Human.class, new EasyRandomParameters());
+        RandomizationContext context = new RandomizationContext(Human.class, new EasyRandomParameters(), null);
         final Human[] currentObjectFromContext = new Human[1];
         when(randomizerProvider.getRandomizerByField(name, context)).thenReturn(contextAwareRandomizer);
         when(contextAwareRandomizer.getRandomValue()).thenReturn(NAME);
@@ -138,7 +138,7 @@ class FieldPopulatorTest {
         Field strings = ArrayBean.class.getDeclaredField("strings");
         ArrayBean arrayBean = new ArrayBean();
         String[] object = new String[0];
-        RandomizationContext context = new RandomizationContext(ArrayBean.class, new EasyRandomParameters());
+        RandomizationContext context = new RandomizationContext(ArrayBean.class, new EasyRandomParameters(), null);
         when(arrayPopulator.getRandomArray(strings.getType(), context)).thenReturn(object);
 
         // When
@@ -154,7 +154,7 @@ class FieldPopulatorTest {
         Field strings = CollectionBean.class.getDeclaredField("typedCollection");
         CollectionBean collectionBean = new CollectionBean();
         Collection<Person> persons = Collections.emptyList();
-        RandomizationContext context = new RandomizationContext(CollectionBean.class, new EasyRandomParameters());
+        RandomizationContext context = new RandomizationContext(CollectionBean.class, new EasyRandomParameters(), null);
 
         // When
         fieldPopulator.populateField(collectionBean, strings, context);
@@ -169,7 +169,7 @@ class FieldPopulatorTest {
         Field strings = MapBean.class.getDeclaredField("typedMap");
         MapBean mapBean = new MapBean();
         Map<Integer, Person> idToPerson = new HashMap<>();
-        RandomizationContext context = new RandomizationContext(MapBean.class, new EasyRandomParameters());
+        RandomizationContext context = new RandomizationContext(MapBean.class, new EasyRandomParameters(), null);
 
         // When
         fieldPopulator.populateField(mapBean, strings, context);

--- a/easy-random-core/src/test/java/org/jeasy/random/RandomizationContextTest.java
+++ b/easy-random-core/src/test/java/org/jeasy/random/RandomizationContextTest.java
@@ -57,7 +57,7 @@ public class RandomizationContextTest {
 
     @BeforeEach
     void setUp() {
-        randomizationContext = new RandomizationContext(Object.class, parameters);
+        randomizationContext = new RandomizationContext(Object.class, parameters, null);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class RandomizationContextTest {
     void whenCurrentStackSizeOverMaxRandomizationDepth_thenShouldExceedRandomizationDepth() throws NoSuchFieldException {
         // Given
         when(parameters.getRandomizationDepth()).thenReturn(1);
-        RandomizationContext customRandomizationContext = new RandomizationContext(Object.class, parameters);
+        RandomizationContext customRandomizationContext = new RandomizationContext(Object.class, parameters, null);
         Field address = Person.class.getDeclaredField("address");
         customRandomizationContext.pushStackItem(new RandomizationContextStackItem(bean1, address));
         customRandomizationContext.pushStackItem(new RandomizationContextStackItem(bean2, address));
@@ -136,7 +136,7 @@ public class RandomizationContextTest {
     void whenCurrentStackSizeLessMaxRandomizationDepth_thenShouldNotExceedRandomizationDepth() throws NoSuchFieldException {
         // Given
         when(parameters.getRandomizationDepth()).thenReturn(2);
-        RandomizationContext customRandomizationContext = new RandomizationContext(Object.class, parameters);
+        RandomizationContext customRandomizationContext = new RandomizationContext(Object.class, parameters, null);
         Field address = Person.class.getDeclaredField("address");
         customRandomizationContext.pushStackItem(new RandomizationContextStackItem(bean1, address));
 
@@ -151,7 +151,7 @@ public class RandomizationContextTest {
     void whenCurrentStackSizeEqualMaxRandomizationDepth_thenShouldNotExceedRandomizationDepth() throws NoSuchFieldException {
         // Given
         when(parameters.getRandomizationDepth()).thenReturn(2);
-        RandomizationContext customRandomizationContext = new RandomizationContext(Object.class, parameters);
+        RandomizationContext customRandomizationContext = new RandomizationContext(Object.class, parameters, null);
         Field address = Person.class.getDeclaredField("address");
         customRandomizationContext.pushStackItem(new RandomizationContextStackItem(bean1, address));
         customRandomizationContext.pushStackItem(new RandomizationContextStackItem(bean2, address));


### PR DESCRIPTION
This will allow custom (ContextAware)Randomizers or custom field populators to access registered randomizers, preventing them the pain of reimplementing registries loading.