### PR TITLE
Make usage of ClassGraphFacade replacable with custom logic in ReflectionUtils

### DIFF
--- a/easy-random-core/src/main/java/org/jeasy/random/util/ClassGraphFacade.java
+++ b/easy-random-core/src/main/java/org/jeasy/random/util/ClassGraphFacade.java
@@ -25,7 +25,6 @@ package org.jeasy.random.util;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfoList;
@@ -37,22 +36,11 @@ import io.github.classgraph.ScanResult;
  *
  * @author Pascal Schumacher (https://github.com/PascalSchumacher)
  */
-abstract class ClassGraphFacade {
+class ClassGraphFacade {
 
-    private static final ConcurrentHashMap<Class<?>, List<Class<?>>> typeToConcreteSubTypes = new ConcurrentHashMap<>();
-    private static final ScanResult scanResult = new ClassGraph().enableSystemJarsAndModules().enableClassInfo().scan();
+    private final static ScanResult scanResult = new ClassGraph().enableSystemJarsAndModules().enableClassInfo().scan();
 
-    /**
-     * Searches the classpath for all public concrete subtypes of the given interface or abstract class.
-     *
-     * @param type to search concrete subtypes of
-     * @return a list of all concrete subtypes found
-     */
-    public static <T> List<Class<?>> getPublicConcreteSubTypesOf(final Class<T> type) {
-        return typeToConcreteSubTypes.computeIfAbsent(type, ClassGraphFacade::searchForPublicConcreteSubTypesOf);
-    }
-
-    private static <T> List<Class<?>> searchForPublicConcreteSubTypesOf(final Class<T> type) {
+    static List<Class<?>> searchForPublicConcreteSubTypesOf(final Class<?> type) {
         String typeName = type.getName();
         ClassInfoList subTypes = type.isInterface() ? scanResult.getClassesImplementing(typeName) : scanResult.getSubclasses(typeName);
         List<Class<?>> loadedSubTypes = subTypes.filter(subType -> subType.isPublic() && !subType.isAbstract()).loadClasses(true);


### PR DESCRIPTION
...by providing user injectable Function, while retaining ClassGraphFacade's lazy loading semantics.

Moves concrete subtype cache to ReflectionUtils.

Additionally:
- All tests pass (as I have built a snapshot for myself).
- I didn't create an issue. Should I?