### PR TITLE
[BUGFIX] Make BeanValidationAnnotationHandler public

### DIFF
--- a/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/BeanValidationAnnotationHandler.java
+++ b/easy-random-bean-validation/src/main/java/org/jeasy/random/validation/BeanValidationAnnotationHandler.java
@@ -28,7 +28,7 @@ import org.jeasy.random.api.Randomizer;
 
 import java.lang.reflect.Field;
 
-interface BeanValidationAnnotationHandler {
+public interface BeanValidationAnnotationHandler {
 
     Randomizer<?> getRandomizer(Field field);
 


### PR DESCRIPTION
That way, extending BeanValidationRandomizerRegistry and appending to annotationHandlers is possible.

This is a follow up for change mentioned [here](https://github.com/j-easy/easy-random/issues/401#issuecomment-604739142) - making the map protected was unfortunately, not enought. The [test was passing](https://github.com/j-easy/easy-random/commit/159869580487e2ecf16bcc1fd890564b0c4d3fcd#diff-b397b0a3111c419b2b61e7e667a04d9c02bc9ecaa091a674fac904250b6211bdR35) because `BeanValidationAnnotationHandler` is in the same package as the test.