### PR TITLE
Add advanced generic and wild-card parse mechanism

### DIFF
--- a/src/main/java/org/jeasy/random/CollectionPopulator.java
+++ b/src/main/java/org/jeasy/random/CollectionPopulator.java
@@ -41,15 +41,18 @@ class CollectionPopulator {
 
     private final EasyRandom easyRandom;
 
-    CollectionPopulator(final EasyRandom easyRandom) {
+    private final GenericResolver genericResolver;
+
+    CollectionPopulator(final EasyRandom easyRandom, final GenericResolver genericResolver) {
         this.easyRandom = easyRandom;
+        this.genericResolver = genericResolver;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     Collection<?> getRandomCollection(final Field field, final RandomizationContext context) {
         int randomSize = getRandomCollectionSize(context.getParameters());
-        Class<?> fieldType = field.getType();
-        Type fieldGenericType = field.getGenericType();
+        Class<?> fieldType = genericResolver.resolveRawFieldType(field, context);
+        Type fieldGenericType = genericResolver.resolveFieldType(field, context);
         Collection collection;
 
         if (isInterface(fieldType)) {

--- a/src/main/java/org/jeasy/random/EasyRandomParameters.java
+++ b/src/main/java/org/jeasy/random/EasyRandomParameters.java
@@ -98,6 +98,7 @@ public class EasyRandomParameters {
     private boolean overrideDefaultInitialization;
     private boolean ignoreRandomizationErrors;
     private boolean bypassSetters;
+    private boolean advancedGenericParseMechanism;
     private Range<Integer> collectionSizeRange;
     private Range<Integer> stringLengthRange;
     private Range<LocalDate> dateRange;
@@ -123,6 +124,7 @@ public class EasyRandomParameters {
         overrideDefaultInitialization = false;
         ignoreRandomizationErrors = false;
         bypassSetters = false;
+        advancedGenericParseMechanism = false;
         objectPoolSize = DEFAULT_OBJECT_POOL_SIZE;
         randomizationDepth = DEFAULT_RANDOMIZATION_DEPTH;
         dateRange = new Range<>(DEFAULT_DATES_RANGE.getMin().toLocalDate(), DEFAULT_DATES_RANGE.getMax().toLocalDate());
@@ -229,6 +231,14 @@ public class EasyRandomParameters {
 
     public void setBypassSetters(boolean bypassSetters) {
         this.bypassSetters = bypassSetters;
+    }
+
+    public boolean isAdvancedGenericParseMechanism() {
+        return advancedGenericParseMechanism;
+    }
+
+    public void setAdvancedGenericParseMechanism(boolean advancedGenericParseMechanism) {
+        this.advancedGenericParseMechanism = advancedGenericParseMechanism;
     }
 
     public ExclusionPolicy getExclusionPolicy() {
@@ -558,6 +568,17 @@ public class EasyRandomParameters {
      */
     public EasyRandomParameters bypassSetters(boolean bypassSetters) {
         setBypassSetters(bypassSetters);
+        return this;
+    }
+
+    /**
+     * Flag to use advanced generic parse mechanism allowed resolve any TypeVariable, WildCards, etc.
+     *
+     * @param advancedGenericParseMechanism true if parse mechanism enabled
+     * @return the current {@link EasyRandomParameters} instance for method chaining
+     */
+    public EasyRandomParameters advancedGenericParseMechanism(boolean advancedGenericParseMechanism) {
+        setAdvancedGenericParseMechanism(advancedGenericParseMechanism);
         return this;
     }
 

--- a/src/main/java/org/jeasy/random/GenericResolver.java
+++ b/src/main/java/org/jeasy/random/GenericResolver.java
@@ -1,0 +1,234 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2023, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenericResolver {
+
+    <T> void resolveInheritanceGenerics(Class<T> klass, RandomizationContext context) {
+        context.pushGenericsContext();
+        if (context.getParameters().isAdvancedGenericParseMechanism()) {
+            resolveCurrentGenerics(klass, context);
+
+            Class<?> previousClass = klass;
+            Type genericSuperclass = klass.getGenericSuperclass();
+            while (genericSuperclass != null && !genericSuperclass.equals(Object.class)) {
+                if (genericSuperclass instanceof ParameterizedType parameterizedType) {
+                    Class<?> rawType = (Class<?>) parameterizedType.getRawType();
+
+                    TypeVariable<?>[] typeParameters = rawType.getTypeParameters();
+                    Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+                    int typeArgumentsCount = typeParameters.length;
+
+                    for (int i = 0; i < typeArgumentsCount; i++) {
+                        TypeVariable<?> typeVariable = typeParameters[i];
+                        Type actualTypeArgument = actualTypeArguments[i];
+
+                        Type resolvedType = resolveType(actualTypeArgument, previousClass, context);
+                        context.addTypeVariableMapping(rawType, typeVariable, resolvedType);
+                    }
+
+                    previousClass = rawType;
+                    genericSuperclass = rawType.getGenericSuperclass();
+                } else if (genericSuperclass instanceof Class<?> superClass) {
+                    previousClass = superClass;
+                    genericSuperclass = superClass.getGenericSuperclass();
+                } else {
+                    genericSuperclass = null;
+                }
+            }
+        }
+    }
+
+    Type resolveFieldType(Field field, RandomizationContext context) {
+        if (context.getParameters().isAdvancedGenericParseMechanism()) {
+            Type genericType = field.getGenericType();
+
+            Type resolvedFieldType = resolveType(genericType, field.getDeclaringClass(), context);
+            if (resolvedFieldType instanceof ParameterizedType parameterizedType) {
+                Class<?> rootClass = (Class<?>) parameterizedType.getRawType();
+                TypeVariable<?>[] typeParameters = rootClass.getTypeParameters();
+                Type[] typeArguments = parameterizedType.getActualTypeArguments();
+                int argumentsCount = typeParameters.length;
+
+                for (int i = 0; i < argumentsCount; i++) {
+                    TypeVariable<?> typeVariable = typeParameters[i];
+                    Type actualTypeArgument = typeArguments[i];
+
+                    context.addFieldTypeVariableMapping(field, typeVariable, actualTypeArgument);
+                }
+            }
+
+            return resolvedFieldType;
+        } else {
+            return field.getGenericType();
+        }
+    }
+
+    Class<?> resolveRawFieldType(Field field, RandomizationContext context) {
+        if (context.getParameters().isAdvancedGenericParseMechanism()) {
+            Type resolvedFieldType = resolveFieldType(field, context);
+            if (resolvedFieldType instanceof Class<?> resolvedClass) {
+                return resolvedClass;
+            } else if (resolvedFieldType instanceof ParameterizedType parameterizedType) {
+                return (Class<?>) parameterizedType.getRawType();
+            }
+        }
+
+        return field.getType();
+    }
+
+    private Type resolveType(Type type, Class<?> contextClass, RandomizationContext context) {
+        if (type instanceof TypeVariable<?> actualTypeVariable) {
+            Type resolvedType = context.resolveTypeVariable(contextClass, actualTypeVariable);
+            if (resolvedType != null) {
+                return resolvedType;
+            }
+        } else if (type instanceof GenericArrayType genericArrayType) {
+            return resolveGenericArrayType(genericArrayType, contextClass, context);
+        } else if (type instanceof ParameterizedType internalParametrizedType) {
+            return resolveParametrizedType(internalParametrizedType, contextClass, context);
+        } else if (type instanceof WildcardType wildcardType) {
+            return resolveWildCardType(wildcardType, contextClass, context);
+        }
+
+        return type;
+    }
+
+    private <T> void resolveCurrentGenerics(Class<T> klass, RandomizationContext context) {
+        TypeVariable<Class<T>>[] initialTypeParameters = klass.getTypeParameters();
+        for (TypeVariable<Class<T>> typeVariable : initialTypeParameters) {
+            Type realType = context.resolveFieldTypeVariable(typeVariable);
+            context.addTypeVariableMapping(klass, typeVariable, realType);
+        }
+    }
+
+    private ParameterizedType resolveParametrizedType(
+            ParameterizedType parameterizedType,
+            Class<?> contextClass,
+            RandomizationContext context
+    ) {
+        List<Type> resolvedTypes = new ArrayList<>();
+
+        for (Type actualTypeArgument : parameterizedType.getActualTypeArguments()) {
+            resolvedTypes.add(resolveType(actualTypeArgument, contextClass, context));
+        }
+
+        return new ParametrizedTypeImpl(
+                resolvedTypes.toArray(new Type[0]),
+                parameterizedType.getRawType(),
+                parameterizedType.getOwnerType()
+        );
+    }
+
+    private Type resolveWildCardType(WildcardType wildcardType, Class<?> contextClass, RandomizationContext context) {
+        Type[] upperBounds = wildcardType.getUpperBounds();
+        if (upperBounds.length == 1) {
+            Type upperBound = upperBounds[0];
+            if (!upperBound.equals(Object.class)) {
+                return resolveType(upperBound, contextClass, context);
+            }
+        }
+
+        Type[] lowerBounds = wildcardType.getLowerBounds();
+        if (lowerBounds.length == 1) {
+            Type lowerBound = lowerBounds[0];
+            if (!lowerBound.equals(Object.class)) {
+                return resolveType(lowerBound, contextClass, context);
+            }
+        }
+
+        return wildcardType;
+    }
+
+    private Type resolveGenericArrayType(
+            GenericArrayType genericArrayType,
+            Class<?> contextClass,
+            RandomizationContext context
+    ) {
+        Type arrayComponentType = genericArrayType.getGenericComponentType();
+        Type resolvedType = resolveType(arrayComponentType, contextClass, context);
+
+        if (resolvedType instanceof Class<?> realClass) {
+            return Array.newInstance(realClass, 0).getClass();
+        } else if (resolvedType instanceof ParameterizedType || resolvedType instanceof GenericArrayType) {
+            return new GenericArrayTypeImpl(resolvedType);
+        } else {
+            return genericArrayType;
+        }
+    }
+
+    private static class ParametrizedTypeImpl implements ParameterizedType {
+
+        private final Type[] actualTypeArguments;
+
+        private final Type rawType;
+
+        private final Type ownerType;
+
+        public ParametrizedTypeImpl(Type[] actualTypeArguments, Type rawType, Type ownerType) {
+            this.actualTypeArguments = actualTypeArguments;
+            this.rawType = rawType;
+            this.ownerType = ownerType;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return actualTypeArguments;
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return ownerType;
+        }
+    }
+
+    private static class GenericArrayTypeImpl implements GenericArrayType {
+
+        private final Type componentType;
+
+        private GenericArrayTypeImpl(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
+}

--- a/src/main/java/org/jeasy/random/MapPopulator.java
+++ b/src/main/java/org/jeasy/random/MapPopulator.java
@@ -46,16 +46,19 @@ class MapPopulator {
 
     private final ObjectFactory objectFactory;
 
-    MapPopulator(final EasyRandom easyRandom, final ObjectFactory objectFactory) {
+    private final GenericResolver genericResolver;
+
+    MapPopulator(final EasyRandom easyRandom, final ObjectFactory objectFactory, final GenericResolver genericResolver) {
         this.easyRandom = easyRandom;
         this.objectFactory = objectFactory;
+        this.genericResolver = genericResolver;
     }
 
     @SuppressWarnings("unchecked")
     Map<?, ?> getRandomMap(final Field field, final RandomizationContext context) {
         int randomSize = getRandomMapSize(context.getParameters());
-        Class<?> fieldType = field.getType();
-        Type fieldGenericType = field.getGenericType();
+        Class<?> fieldType = genericResolver.resolveRawFieldType(field, context);
+        Type fieldGenericType = genericResolver.resolveFieldType(field, context);
         Map<Object, Object> map;
 
         if (isInterface(fieldType)) {

--- a/src/test/java/org/jeasy/random/AdvancedGenericsTest.java
+++ b/src/test/java/org/jeasy/random/AdvancedGenericsTest.java
@@ -1,0 +1,180 @@
+/*
+ * The MIT License
+ *
+ *   Copyright (c) 2023, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package org.jeasy.random;
+
+import org.jeasy.random.beans.TestEnum;
+import org.jeasy.random.beans.generics.ClassWithGenericArray;
+import org.jeasy.random.beans.generics.ClassWithCommonGeneric;
+import org.jeasy.random.beans.generics.ClassWithArrayImpl;
+import org.jeasy.random.beans.generics.ClassWithArrayInGeneric;
+import org.jeasy.random.beans.generics.ClassWithList;
+import org.jeasy.random.beans.generics.ClassDifficultImpl;
+import org.jeasy.random.beans.generics.ClassStringImpl;
+import org.jeasy.random.beans.generics.ClassWithListInGenericImpl;
+import org.jeasy.random.beans.generics.ClassUnusedGenericInInheritance;
+import org.jeasy.random.beans.generics.ClassWithTwoDimArrayImpl;
+import org.jeasy.random.beans.generics.ClassWithGenericFieldImpl;
+import org.jeasy.random.beans.generics.ClassWithReThrownGeneric;
+import org.jeasy.random.beans.generics.ClassUnusedGenericField;
+import org.jeasy.random.beans.generics.ClassWithTwoLevelGeneric;
+import org.jeasy.random.beans.generics.ClassWithFieldTwoLevelGeneric;
+import org.jeasy.random.beans.generics.ClassWithWildCards;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AdvancedGenericsTest {
+
+    private final EasyRandom easyRandom = new EasyRandom(new EasyRandomParameters()
+            .advancedGenericParseMechanism(true));
+
+    @Test
+    void commonGenericTest() {
+        ClassStringImpl object = easyRandom.nextObject(ClassStringImpl.class);
+        String genericField = object.getGenericField();
+
+        assertThat(genericField).isNotEmpty();
+    }
+
+    @Test
+    void commonListGenericTest() {
+        ClassWithListInGenericImpl object = easyRandom.nextObject(ClassWithListInGenericImpl.class);
+        List<String> genericField = object.getGenericField();
+
+        assertThat(genericField).isNotEmpty();
+    }
+
+    @Test
+    void commonArrayTest() {
+        ClassWithArrayInGeneric object = easyRandom.nextObject(ClassWithArrayInGeneric.class);
+        String[] genericField = object.getGenericField();
+
+        assertThat(genericField).isNotEmpty();
+    }
+
+    @Test
+    void nonDeterminateGenericTest() {
+        assertThrows(ObjectCreationException.class, () -> {
+            easyRandom.nextObject(ClassWithReThrownGeneric.class);
+        });
+    }
+
+    @Test
+    void twoLevelGenericTest() {
+        ClassWithTwoLevelGeneric object = easyRandom.nextObject(ClassWithTwoLevelGeneric.class);
+        Integer genericField = object.getGenericField();
+
+        assertThat(genericField).isNotNull();
+    }
+
+    @Test
+    void determinateArrayCommonGenericTest() {
+        ClassWithArrayImpl object = easyRandom.nextObject(ClassWithArrayImpl.class);
+        String[] genericField = object.getGenericArray();
+
+        assertThat(genericField).isNotEmpty();
+    }
+
+    @Test
+    void determinateTwoLevelArrayCommonGenericTest() {
+        ClassWithTwoDimArrayImpl object = easyRandom.nextObject(ClassWithTwoDimArrayImpl.class);
+        Integer[][] genericField = object.getGenericArray();
+
+        assertThat(genericField).isNotEmpty();
+    }
+
+    @Test
+    void determinateCollectionCommonGenericTest() {
+        ClassWithList object = easyRandom.nextObject(ClassWithList.class);
+        List<String> genericList = object.getGenericList();
+
+        assertThat(genericList).isNotEmpty();
+    }
+
+    @Test
+    void genericFieldTest() {
+        ClassWithGenericFieldImpl object = easyRandom.nextObject(ClassWithGenericFieldImpl.class);
+        ClassWithGenericArray<String> arrayCommonGeneric = object.getGenericField();
+
+        String[] genericArray = arrayCommonGeneric.getGenericArray();
+
+        assertThat(genericArray).isNotEmpty();
+    }
+
+    @Test
+    void twoLevelGenericFieldTest() {
+        ClassWithFieldTwoLevelGeneric object = easyRandom.nextObject(ClassWithFieldTwoLevelGeneric.class);
+        ClassWithReThrownGeneric<Integer> genericField = object.getGenericField();
+        Integer integerGenericField = genericField.getGenericField();
+
+        assertThat(integerGenericField).isNotNull();
+    }
+
+    @Test
+    void difficultGenericTest() {
+        ClassDifficultImpl object = easyRandom.nextObject(ClassDifficultImpl.class);
+        List<ClassWithReThrownGeneric<Integer>> genericList = object.getGenericList();
+        ClassWithReThrownGeneric<Double> genericField = object.getGenericField();
+
+        for (ClassWithReThrownGeneric<Integer> integerNonDeterminateGeneric : genericList) {
+            Integer integerGeneric = integerNonDeterminateGeneric.getGenericField();
+            assertThat(integerGeneric).isNotNull();
+        }
+
+        Double doubleGeneric = genericField.getGenericField();
+        assertThat(doubleGeneric).isNotNull();
+    }
+
+    @Test
+    void wildCardBaseTest() {
+        ClassWithWildCards object = easyRandom.nextObject(ClassWithWildCards.class);
+        List<? super Integer> wildCardLowerList = object.getWildCardLowerList();
+        List<? extends Integer> wildCardUpperList = object.getWildCardUpperList();
+        List<? extends TestEnum> wildCardeEumList = object.getWildCardeEumList();
+
+        assertThat(wildCardLowerList).isNotEmpty();
+        assertThat(wildCardUpperList).isNotEmpty();
+        assertThat(wildCardeEumList).isNotEmpty();
+    }
+
+    @Test
+    void determinateNonGenericTest() {
+        ClassUnusedGenericInInheritance object = easyRandom.nextObject(ClassUnusedGenericInInheritance.class);
+        Object genericField = object.getGenericField();
+
+        assertThat(genericField).isNotNull();
+    }
+
+    @Test
+    void nonDeterminateGenericFieldTest() {
+        ClassUnusedGenericField object = easyRandom.nextObject(ClassUnusedGenericField.class);
+        ClassWithCommonGeneric<?> commonGeneric = object.getCommonGeneric();
+        Object genericField = commonGeneric.getGenericField();
+
+        assertThat(genericField).isNotNull();
+    }
+}

--- a/src/test/java/org/jeasy/random/CollectionPopulatorTest.java
+++ b/src/test/java/org/jeasy/random/CollectionPopulatorTest.java
@@ -67,7 +67,8 @@ class CollectionPopulatorTest {
     @BeforeEach
     void setUp() {
         parameters = new EasyRandomParameters().collectionSizeRange(SIZE, SIZE);
-        collectionPopulator = new CollectionPopulator(easyRandom);
+        GenericResolver genericResolver = new GenericResolver();
+        collectionPopulator = new CollectionPopulator(easyRandom, genericResolver);
     }
 
     /*

--- a/src/test/java/org/jeasy/random/FieldPopulatorTest.java
+++ b/src/test/java/org/jeasy/random/FieldPopulatorTest.java
@@ -72,11 +72,14 @@ class FieldPopulatorTest {
     @Mock
     private OptionalPopulator optionalPopulator;
 
+    @Mock
+    private GenericResolver genericResolver;
+
     private FieldPopulator fieldPopulator;
 
     @BeforeEach
     void setUp() {
-        fieldPopulator = new FieldPopulator(easyRandom, randomizerProvider, arrayPopulator, collectionPopulator, mapPopulator, optionalPopulator);
+        fieldPopulator = new FieldPopulator(easyRandom, randomizerProvider, arrayPopulator, collectionPopulator, mapPopulator, optionalPopulator, genericResolver);
     }
 
     @Test

--- a/src/test/java/org/jeasy/random/MapPopulatorTest.java
+++ b/src/test/java/org/jeasy/random/MapPopulatorTest.java
@@ -66,7 +66,8 @@ class MapPopulatorTest {
     void setUp() {
         parameters = new EasyRandomParameters().collectionSizeRange(SIZE, SIZE);
         ObjectFactory objectFactory = new ObjenesisObjectFactory();
-        mapPopulator = new MapPopulator(easyRandom, objectFactory);
+        GenericResolver genericResolver = new GenericResolver();
+        mapPopulator = new MapPopulator(easyRandom, objectFactory, genericResolver);
     }
 
     /*

--- a/src/test/java/org/jeasy/random/beans/generics/ClassDifficultImpl.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassDifficultImpl.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassDifficultImpl extends ClassWithDifficultGeneric<Integer> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassStringImpl.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassStringImpl.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassStringImpl extends ClassWithCommonGeneric<String> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassUnusedGenericField.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassUnusedGenericField.java
@@ -1,0 +1,14 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassUnusedGenericField {
+
+    private ClassWithCommonGeneric commonGeneric;
+
+    public ClassWithCommonGeneric getCommonGeneric() {
+        return commonGeneric;
+    }
+
+    public void setCommonGeneric(ClassWithCommonGeneric commonGeneric) {
+        this.commonGeneric = commonGeneric;
+    }
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassUnusedGenericInInheritance.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassUnusedGenericInInheritance.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassUnusedGenericInInheritance extends ClassWithCommonGeneric {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithArrayImpl.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithArrayImpl.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithArrayImpl extends ClassWithGenericArray<String> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithArrayInGeneric.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithArrayInGeneric.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithArrayInGeneric extends ClassWithCommonGeneric<String[]> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithCommonGeneric.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithCommonGeneric.java
@@ -1,0 +1,14 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithCommonGeneric<T> {
+
+    private T genericField;
+
+    public T getGenericField() {
+        return genericField;
+    }
+
+    public void setGenericField(T genericField) {
+        this.genericField = genericField;
+    }
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithDifficultGeneric.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithDifficultGeneric.java
@@ -1,0 +1,16 @@
+package org.jeasy.random.beans.generics;
+
+import java.util.List;
+
+public class ClassWithDifficultGeneric<T extends Integer> extends ClassWithCommonGeneric<ClassWithReThrownGeneric<Double>> {
+
+    private List<ClassWithReThrownGeneric<T>> genericList;
+
+    public List<ClassWithReThrownGeneric<T>> getGenericList() {
+        return genericList;
+    }
+
+    public void setGenericList(List<ClassWithReThrownGeneric<T>> genericList) {
+        this.genericList = genericList;
+    }
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithFieldTwoLevelGeneric.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithFieldTwoLevelGeneric.java
@@ -1,0 +1,14 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithFieldTwoLevelGeneric {
+
+    private ClassWithReThrownGeneric<Integer> genericField;
+
+    public ClassWithReThrownGeneric<Integer> getGenericField() {
+        return genericField;
+    }
+
+    public void setGenericField(ClassWithReThrownGeneric<Integer> genericField) {
+        this.genericField = genericField;
+    }
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithGenericArray.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithGenericArray.java
@@ -1,0 +1,14 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithGenericArray<T> {
+
+    private T[] genericArray;
+
+    public T[] getGenericArray() {
+        return genericArray;
+    }
+
+    public void setGenericArray(T[] genericArray) {
+        this.genericArray = genericArray;
+    }
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithGenericFieldImpl.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithGenericFieldImpl.java
@@ -1,0 +1,14 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithGenericFieldImpl {
+
+    private ClassWithGenericArray<String> genericField;
+
+    public ClassWithGenericArray<String> getGenericField() {
+        return genericField;
+    }
+
+    public void setGenericField(ClassWithGenericArray<String> genericField) {
+        this.genericField = genericField;
+    }
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithGenericList.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithGenericList.java
@@ -1,0 +1,16 @@
+package org.jeasy.random.beans.generics;
+
+import java.util.List;
+
+public class ClassWithGenericList<T> {
+
+    private List<T> genericList;
+
+    public List<T> getGenericList() {
+        return genericList;
+    }
+
+    public void setGenericList(List<T> genericList) {
+        this.genericList = genericList;
+    }
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithList.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithList.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithList extends ClassWithGenericList<String> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithListInGenericImpl.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithListInGenericImpl.java
@@ -1,0 +1,6 @@
+package org.jeasy.random.beans.generics;
+
+import java.util.List;
+
+public class ClassWithListInGenericImpl extends ClassWithCommonGeneric<List<String>> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithReThrownGeneric.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithReThrownGeneric.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithReThrownGeneric<K extends Number> extends ClassWithCommonGeneric<K> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithTwoDimArray.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithTwoDimArray.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithTwoDimArray<T> extends ClassWithGenericArray<T[]> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithTwoDimArrayImpl.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithTwoDimArrayImpl.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithTwoDimArrayImpl extends ClassWithTwoDimArray<Integer> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithTwoLevelGeneric.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithTwoLevelGeneric.java
@@ -1,0 +1,4 @@
+package org.jeasy.random.beans.generics;
+
+public class ClassWithTwoLevelGeneric extends ClassWithReThrownGeneric<Integer> {
+}

--- a/src/test/java/org/jeasy/random/beans/generics/ClassWithWildCards.java
+++ b/src/test/java/org/jeasy/random/beans/generics/ClassWithWildCards.java
@@ -1,0 +1,38 @@
+package org.jeasy.random.beans.generics;
+
+import org.jeasy.random.beans.TestEnum;
+
+import java.util.List;
+
+public class ClassWithWildCards {
+
+    private List<? extends Integer> wildCardUpperList;
+
+    private List<? super Integer> wildCardLowerList;
+
+    private List<? extends TestEnum> wildCardeEumList;
+
+    public List<? extends Integer> getWildCardUpperList() {
+        return wildCardUpperList;
+    }
+
+    public void setWildCardUpperList(List<? extends Integer> wildCardUpperList) {
+        this.wildCardUpperList = wildCardUpperList;
+    }
+
+    public List<? super Integer> getWildCardLowerList() {
+        return wildCardLowerList;
+    }
+
+    public void setWildCardLowerList(List<? super Integer> wildCardLowerList) {
+        this.wildCardLowerList = wildCardLowerList;
+    }
+
+    public List<? extends TestEnum> getWildCardeEumList() {
+        return wildCardeEumList;
+    }
+
+    public void setWildCardeEumList(List<? extends TestEnum> wildCardeEumList) {
+        this.wildCardeEumList = wildCardeEumList;
+    }
+}


### PR DESCRIPTION
Hello!
We use your library for generating random values for our model. Our model has difficult generic and easy-random can't determinate some generic and skipped it. But we require fill all models by non null or empty values. So we decided to fix it in easy-random
From our side, it's look like a fix, but changes a little large :)
We understand about maintenance mode in easy-random, but I hope our changes will accepted like fix. In otherwise we will have to fork it. But we don't want to create our fork. I add that changes by flag, so current behavior not changed.

Thank you for library!

---

Thank you for taking time to contribute this pull request :smile:

You have probably already checked the following points, but as a reminder, please ensure that:

* your branch is rebased on the latest version of the master branch
* all tests pass
* code is formatted with IntelliJ Idea default settings (if you use another IDE, never mind, ignore this point)

You may add the reference of the issue in your commit message.

Don't hesitate to add your name to the contributors list in the `README.md` file.

Many thanks upfront!
